### PR TITLE
Remove redundancies

### DIFF
--- a/privacy_extended.txt
+++ b/privacy_extended.txt
@@ -1,3 +1,6 @@
+Privacy Extended after removing internal duplicates and redundancies with EasyPrivacy.
+11 March 2023
+
 ! Title: Privacy Extended
 ! Description: Privacy filters forked from Adguard Tracking Protection, optimized for uBlock Origin
 ! Expires: 12 hours
@@ -270,7 +273,6 @@ cartune.me#?#.contents-inner > div > div#taboola-alternating-thumbnails-a:upward
 ||tracking.shaadi.com^
 ||tdbc.redgalaxy.com^$3p
 ||t.c-rtb.com^
-||t.ssp.hinet.net^
 ||bb8.aotter.net^
 ||dmkt.point-ad-game.com^
 ||tag.dec-connect.decsuite.com^
@@ -1308,16 +1310,12 @@ cartune.me#?#.contents-inner > div > div#taboola-alternating-thumbnails-a:upward
 ||scarcestream.com^$3p
 ||shakesea.com^$3p
 ||pocketsonic.com^$3p
-||measlymiddle.com^
-||exchangedetail.com^
 !
 ! TikTok
 ||rtc-logger-va.tiktokv.com^
-||rtlog.tiktokv.com^
 ||mon-*.tiktokv.com^
 ||mon.tiktokv.com^
 ||xlog.tiktokv.com^
-||xlog-va.tiktokv.com^
 ||log*-*.tiktokv.com^
 ||xlog*-*.tiktokv.com^
 ||mcs-va-*.tiktokv.com^
@@ -1338,7 +1336,6 @@ cartune.me#?#.contents-inner > div > div#taboola-alternating-thumbnails-a:upward
 ||screenshots.goguardian.com^
 ||snat.goguardian.com^
 ||sock*-goguardian.pusher.com^
-||sockjs-goguardian.pusher.com^
 ||ws-goguardian.pusher.com^
 ||x3-policy-maker.goguardian.com^
 ||x3-predictor.goguardian.com^
@@ -1386,7 +1383,6 @@ cartune.me#?#.contents-inner > div > div#taboola-alternating-thumbnails-a:upward
 ! it's problematic that due to how Gmail proxy work, these domains aren't even exposed on the network level
 ! fortunately, extensions can see them (Gmail puts the real URL in the location.hash part of the src)
 ! Shutterstock
-shutterstockmail.com/pub/as?_ri_=$image
 ! Stackcommerce
 track.email.stackcommerce.com/q/$image
 ! MailTrack
@@ -1397,7 +1393,6 @@ t.sidekickopen$image
 t.sigopn$image
 t.senal$image
 t.signaux$image
-t.signauxtrois.com$image
 t.hubspotemail.net/e2t/o$image
 t.hsms06.com$image
 ! Boomerang (boomeranggmail.com)
@@ -1469,13 +1464,11 @@ polymail.io/v2/z$image
 ! YAMM
 yamm-track.appspot$image
 ! GetResponse
-/open.html?x=$image
 ! Close.io
 close.io/email_opened$image
 ! Return Path
 returnpath.net/pixel.gif$image
 ! NetHunt
-nethunt.com/api/v1/track/email/$image
 ! JiveOn tracking
 /mpss/o/*$image
 ! Marketo tracking (see https://docs.marketo.com/display/public/DOCS/Configure+Protocols+for+Marketo)
@@ -1504,7 +1497,6 @@ nethunt.com/api/v1/track/email/$image
 ! Blocking piwik analytics subdomain(for DNS filtering)
 |piwik.
 !
-||tracker.hdtvcloud.com^
 ||mtm.walls.io^
 ||analytics.slidesai.io^
 ||idat.production.ippen.space^
@@ -1524,7 +1516,6 @@ nethunt.com/api/v1/track/email/$image
 ||trace.51jingying.com^
 ||ss.webdock.io^
 ||events.webdock.io^
-||mixpanel-proxy.ted.com^
 ||zc.adswizz.com^
 ||collect.nature.com^
 ||collector.xhwide8.com^
@@ -1552,10 +1543,6 @@ nethunt.com/api/v1/track/email/$image
 ||analytics.zoomit.ir^
 ||pixel.ex.co^
 ||ad*.ettoday.net^
-||servo-report.dvdfab.at^
-||servo-report.dvdfab.cn^
-||servo-report.dvdfab.co.jp^
-||servo-report.dvdfab.fr^
 ||analytics-wcms.joins.net^
 ||as.tarnkappe.info^
 ||analytics.mall.tv^
@@ -1606,7 +1593,6 @@ nethunt.com/api/v1/track/email/$image
 ||d2cmqkwo8rxlr9.cloudfront.net^
 ||log.haberturk.com^
 ||analytics.helpukrainewinwidget.org^
-||event-collector.prd.data.s.joyn.de^
 ||clanker-events.squarespace.com^
 ||p.ura.news^
 ||statsapi.tiendeo.com.tr^
@@ -1614,7 +1600,6 @@ nethunt.com/api/v1/track/email/$image
 ||analytics.vpplayer.tech^
 ||h.seznam.cz^
 ||t.xoom.com^
-||monorail-edge.shopifysvc.com^
 ||pixel.dmdi.pl^
 ||middleware.p7s1.io^
 ||player-feedback.p7s1video.net^
@@ -1740,7 +1725,6 @@ nethunt.com/api/v1/track/email/$image
 ||analytics.cn.ru^
 ||analytics.data.visenze.com^
 ||analytics.dpd.com^
-||analytics.edgekey.net^
 ||analytics.edgesuite.net^
 ||analytics.electro-com.ru^
 ||analytics.fairfax.com.au^
@@ -1749,11 +1733,9 @@ nethunt.com/api/v1/track/email/$image
 ||analytics.go.com^
 ||analytics.gorillanation.com^
 ||analytics.histmag.org^
-||analytics.htmedia.in^
 ||analytics.ifood.tv^
 ||analytics.islamicfinder.org^
 ||analytics.jabong.com^
-||analytics.localytics.com^
 ||analytics.ma.tune.com^
 ||analytics.maileon.com^
 ||analytics.marquiz.ru^
@@ -1808,7 +1790,6 @@ nethunt.com/api/v1/track/email/$image
 ||apetite.index.hr^
 ||api-adservices.apple.com^
 ||api-analytics.rozetka.com.ua^
-||api.amplitude.com^
 ||api.calq.io^
 ||api.exc.mob.com^
 ||api.flocktory.com^
@@ -1844,9 +1825,7 @@ nethunt.com/api/v1/track/email/$image
 ||b-aws.aol.com^
 ||b.aol.com^
 ||b.grvcdn.com^
-||b.karte.io^
 ||b.oix.net^
-||b0.yahoo.co.jp^
 ||bc.nhk.jp^
 ||bcd.esprit.de^
 ||bdg-analytics.appspot.com^
@@ -1871,7 +1850,6 @@ nethunt.com/api/v1/track/email/$image
 ||beacons.helium.com^
 ||beam.remp.impresa.pt^
 ||behave.noen.at^
-||behavior.tongdun.net^
 ||beta.simpel.nl^
 ||bi-eventtracker-*.amazonaws.com^
 ||bi-pipeline-collector.stylight.net^
@@ -1956,7 +1934,6 @@ nethunt.com/api/v1/track/email/$image
 ||cnt.xhamster.com^
 ||cnt.yeptube.
 ||cntcerber.rambler.ru^
-||cntxtfl.com^
 ||code.lockbot.net^
 ||codes.royalad.pl^
 ||collect-elb-*.amazonaws.com^
@@ -1985,12 +1962,10 @@ nethunt.com/api/v1/track/email/$image
 ||collector.szlcsc.com^
 ||collector.tescocompare.com^
 ||collector.trendmd.com^
-||collector.wawlabs.com^
 ||collector.xhwide1.com^
 ||collector1.xhamster.com^
 ||comet.sputniknews.com^
 ||conf.international.baidu.com^
-||cookie.codemarketing.cloud^
 ||cookie.fuel451.com^
 ||count.channeladvisor.com^
 ||count.livetv.ru^
@@ -2011,7 +1986,6 @@ nethunt.com/api/v1/track/email/$image
 ||counter.nv.ua^
 ||counter.ok.ee^
 ||counter.opinion.com.ua^
-||counter.pixplug.in^
 ||counter.promodeejay.net^
 ||counter.rian.ru^
 ||counter.scribblelive.net^
@@ -2034,10 +2008,8 @@ nethunt.com/api/v1/track/email/$image
 ||curiosity-seven.vercel.app^
 ||customerevents.netflix.com^
 ||cwt.citywire.info^
-||d-collector.jennifersoft.com^
 ||d.adtriba.com^
 ||d.email.forbes.com^
-||d.impactradius-event.com^
 ||d.sondakika.com^
 ||d14pdm1b7fi5kh.cloudfront.net^
 ||d17tqr44y57o31.cloudfront.net^
@@ -2118,7 +2090,6 @@ nethunt.com/api/v1/track/email/$image
 ||delog.afreecatv.com^
 ||detwzgl8cvciv.cloudfront.net^
 ||device-analytics.rollout.io^
-||device-metrics-us*.amazon.com^
 ||df.tanx.com^
 ||discovery-script.newspic.kr^
 ||discovery.newspic.kr^
@@ -2126,7 +2097,6 @@ nethunt.com/api/v1/track/email/$image
 ||djibeacon.dowjoneson.com^
 ||djtflbt20bdde.cloudfront.net^
 ||dkhywqapojyk7.cloudfront.net^
-||dkotrack.com^
 ||dmc1acwvwny3.cloudfront.net^
 ||dmp.citiservi.es^
 ||dmtracking2.alibaba.com^
@@ -2145,14 +2115,11 @@ nethunt.com/api/v1/track/email/$image
 ||e-stat.huya.com^
 ||e.dr-zh.com^
 ||e.reddit.com^
-||e.tw.cx^
 ||e2e.mashable.com^
 ||ea.aujourdhui.com^
 ||ea.officedepot.fr^
-||edge.quantserve.com^
 ||ems.youku.com^
 ||epiv.cardlytics.com^
-||er.mmi.bemobile.ua^
 ||er.search.naver.com^
 ||err.rambler.ru^
 ||estat.zum.com^
@@ -2258,7 +2225,6 @@ nethunt.com/api/v1/track/email/$image
 ||heartbeats.prd.data.s.joyn.de^
 ||hindsight.significanceapps.com^
 ||hit-pool.upscore.io^
-||hit.8digits.com^
 ||hit.copesa.cl^
 ||hit.darmoweliczniki.pl^
 ||hit.demirorenteknoloji.com^
@@ -2341,7 +2307,6 @@ nethunt.com/api/v1/track/email/$image
 ||lexip.4players.de^
 ||librato-collector.genius.com^
 ||live.ec2.cxo.name^
-||live.rezync.com^
 ||lively-collect-elb-*.amazonaws.com^
 ||log-live.direct.ly^
 ||log-player.arte.tv^
@@ -2434,7 +2399,6 @@ nethunt.com/api/v1/track/email/$image
 ||metrics.infranken.de^
 ||metrics.pacsun.com^
 ||metrics.tbliab.net^
-||metrics.ted.com^
 ||metrics.toysrus.com^
 ||metrigo.zalan.do^
 ||metrika.kontur.ru^
@@ -2493,7 +2457,6 @@ nethunt.com/api/v1/track/email/$image
 ||omapi.fangraphs.com^
 ||onclickpredictiv.com^
 ||ovk.xceler8.io^
-||p-events.ivideosmart.com^
 ||p.alcmpn.com^
 ||p.gm99.com^
 ||p.imgur.com^
@@ -2510,7 +2473,6 @@ nethunt.com/api/v1/track/email/$image
 ||partner.shareaholic.com^
 ||pasta.esfile.duapps.com^
 ||pc3.vanmoof.com^
-||pebed.dm-event.net^
 ||perr.hola.org^
 ||phen.fabricmedia.ru^
 ||phiesi.stroeerdp.de^
@@ -2551,7 +2513,6 @@ nethunt.com/api/v1/track/email/$image
 ||pixel.wp.pl^$important
 ||pixelappcollector.thesun.co.uk^
 ||pixel*.adswizz.com
-||pixel.randi.adswizz.com
 ||pixelhere.com^
 ||pixels.ingbank.com.tr^
 ||pixels.livingsocial.com^
@@ -2591,7 +2552,6 @@ nethunt.com/api/v1/track/email/$image
 ||reveal.clearbit.com^
 ||revi.rcs.it^
 ||rferl.c.goolara.net^
-||rosenberg.appmetrica.yandex.net^
 ||rrss.abc.es^
 ||rtax.criteo.com^
 ||rtb.softcube.com^
@@ -2649,10 +2609,8 @@ nethunt.com/api/v1/track/email/$image
 ||st.dynamicyield.com^
 ||st.top100.ru^
 ||sta.tracedock.com^
-||stags.bluekai.com^
 ||stat.4u.pl^
 ||stat.adguard.com^
-||stat.adultium.com^
 ||stat.alibaba.com^
 ||stat.alloha.tv^
 ||stat.arzamas.academy^
@@ -2666,7 +2624,6 @@ nethunt.com/api/v1/track/email/$image
 ||stat.nate.com^
 ||stat.novostimira.com^
 ||stat.php-d.com^
-||stat.radar.imgsmail.ru^
 ||stat.rare.ru^
 ||stat.ruvr.ru^
 ||stat.scroogefrog.com^
@@ -2746,7 +2703,6 @@ nethunt.com/api/v1/track/email/$image
 ||stats.video.search.yahoo.com^
 ||stats.videodelivery.net^
 ||stats.videoseyredin.net^
-||stats.vidyome.com^
 ||stats.visistat.com^
 ||stats.walytics.com^
 ||stats.wwd.com^
@@ -2800,8 +2756,6 @@ nethunt.com/api/v1/track/email/$image
 ||tag.datariver.ru^
 ||tag.escalated.io^
 ||tag.nifty.com^
-||tags.bluekai.com^
-||targeting.tbt.arcpublishing.com^
 ||tc-log.mattel163.com^
 ||tc.tradetracker.net^
 ||tdapi.wickey.nl^
@@ -2880,7 +2834,6 @@ nethunt.com/api/v1/track/email/$image
 ||track.ft.com^
 ||track.fxstreet.com^
 ||track.gawker.com^
-||track.leadhit.io^
 ||track.libii.cn^
 ||track.lobi.co^
 ||track.miro.com^
@@ -2896,7 +2849,6 @@ nethunt.com/api/v1/track/email/$image
 ||track.promptfile.com^
 ||track.push-ad.com^
 ||track.pushbullet.com^
-||track.securedvisit.com^
 ||track.slideshare.net^
 ||track.spots.im^
 ||track.tenjin.io^
@@ -2941,7 +2893,6 @@ nethunt.com/api/v1/track/email/$image
 ||tracker.revip.info^
 ||tracker.secretescapes.com^
 ||tracker.stats.in.th^
-||tracker.twenga.pl^
 ||tracker.washtimes.com^
 ||tracker.wordstream.com^
 ||trackers.adtarget.me^
@@ -3014,7 +2965,6 @@ nethunt.com/api/v1/track/email/$image
 ||trk.i0.cz^
 ||trk.lightdatahouse.com^
 ||trk.storyly.io^
-||trk.vidible.tv^
 ||trk*.vidible.tv^
 ||ttauri.laptopmag.com^
 ||two.tracedock.com^
@@ -3069,7 +3019,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||f857.hearstmediatx.com^
 ||j158.hearstmediact.com^
 ||l997.lmtonline.com^
-||n730.timesunion.com^
 ||p593.seattlepi.com^
 ||r541.houstonchronicle.com^
 ||s232.theintelligencer.com^
@@ -3086,7 +3035,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ! Big Star Labs
 ||api2.poperblocker.com^
 ||ben.crxmouse.com^
-||taskapi.net^
 
 ! start: unimania
 ||collection-endpoint-prod.herokuapp.com^
@@ -4027,8 +3975,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||kaweahdelta.hrm.healthgrades.com^
 ||learn.openlending.com^
 ||lp.mnp.ca^
-||lubricationde.promo.skf.com^
-||lubricationus.promo.skf.com^
 ||m.transfix.io^
 ||marketing.3mark.com^
 ||marketing.acadian-asset.com^
@@ -4088,7 +4034,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||mm.morrellinc.com^
 ||msbainfo.fbe.hku.hk^
 ||news.strategiccfo360.com^
-||nordic.promo.skf.com^
 ||overlakemedicalcenter.hrm.healthgrades.com^
 ||palmettohealth.hrm.healthgrades.com^
 ||personal.hubinternational.com^
@@ -4101,8 +4046,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||resources.acarasolutions.com^
 ||resources.talentrise.com^
 ||riverview.hrm.healthgrades.com^
-||rs.promo.skf.com^
-||russia.promo.skf.com^
 ||scmarketing.colliers.com^
 ||sedgwickpooling.sedgwick.com^
 ||seniorliving.sagewoodlcs.com^
@@ -4113,10 +4056,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||thechristhospital.hrm.healthgrades.com^
 ||umassmemorial.hrm.healthgrades.com^
 ||unchealthcare.hrm.healthgrades.com^
-||vehicleaftermarket.eus.promo.skf.com^
-||vietnam.promo.skf.com^
-||vsmeue.promo.skf.com^
-||vsmeus.promo.skf.com^
 ||web.yourerc.com^
 ||welcome.hubinternational.com^
 ||www.bmi.marketing-bmiimaging.com^
@@ -4322,7 +4261,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||a45411.actonservice.com^
 ||a45437.actonservice.com^
 ||aad.actonservice.com^
-||aahamarketing.hubinternational.com^
 ||aajtech.actonservice.com^
 ||acendas.actonservice.com^
 ||act-on.snb.com^
@@ -4333,7 +4271,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||acton.nuvi.com^
 ||acton.sightlife.org^
 ||administrator.pnclassaction.com^
-||advisers.kingstonsmith.co.uk^
 ||aeromark.actonservice.com^
 ||alereinc.actonservice.com^
 ||almalasers.actonservice.com^
@@ -4342,14 +4279,10 @@ charlestownwyllie.oaklawnnonantum.com^
 ||aqr.actonservice.com^
 ||arrayasolutions.actonservice.com^
 ||ascassociation.actonservice.com^
-||asiamarketing.sedgwick.com^
 ||association.locktonaffinity.net^
 ||astromed.actonservice.com^
 ||atlantic-general-hospital.hrm.healthgrades.com^
-||austria.promo.skf.com^
-||axisgroupbenefits.axiscapital.com^
 ||bakercommunications.actonservice.com^
-||baltics.promo.skf.com^
 ||bayarea.summitry.com^
 ||beaconhealthsystem.hrm.healthgrades.com^
 ||beta.actonservice.com^
@@ -4358,7 +4291,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||biworldwide.actonservice.com^
 ||blackhillsgroup.actonservice.com^
 ||blockchain.actonservice.com^
-||blueinfo.marugroup.net^
 ||bobswatches.actonservice.com^
 ||br.bio-rad.com^
 ||bringg.actonservice.com^
@@ -4370,8 +4302,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||camarketing.allegion.com^
 ||camchealth.hrm.healthgrades.com^
 ||campaigns.ashfieldengage.com^
-||carle.hrm.healthgrades.com^
-||catharsisproductionsmarketing.catharsisproductions.com^
 ||cc.pennstatehealth.org^
 ||centrastate.hrm.healthgrades.com^
 ||childrens.hrm.healthgrades.com^
@@ -4389,7 +4319,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||communicatie.nti.nl^
 ||communications.ameritrustgroup.com^
 ||communications.foyston.com^
-||communications.prodways.com^
 ||communications.usfleettracking.com^
 ||community.axiscapital.com^
 ||conference.flsmidth.com^
@@ -4397,15 +4326,10 @@ charlestownwyllie.oaklawnnonantum.com^
 ||connect.corecreative.health^
 ||connect.digi.com^
 ||connect.myokuma.com^
-||connect.riseengineering.com^
 ||connect.shopezrentals.com^
 ||connect.thinkinterval.com^
-||connect.uniti.com^
 ||content.rightsourcemarketing.com^
 ||corporatecommunications.bvifsc.vg^
-||crmcommunications.progressive.com^
-||cure.truefaced.com^
-||cz.promo.skf.com^
 ||de.sharpmarketing.eu^
 ||dealerrelations.cargurus.com^
 ||deepcrawl.actonservice.com^
@@ -4414,21 +4338,14 @@ charlestownwyllie.oaklawnnonantum.com^
 ||dialog.wob.ag^
 ||digital.setpointis.com^
 ||digitalmarketing.nglantz.com^
-||dignityhealth.hrm.healthgrades.com^
-||discover.covenanthealthcare.com^
 ||distribution.provenpharma.com^
 ||dm.syntelli.com^
-||dmc.romotur.com^
 ||drivescale.actonservice.com^
 ||dynovo.actonservice.com^
 ||e.replacementdevicelawsuit.com^
-||e.unchealthcare.org^
-||ecp.bdoaustralia.bdo.com.au^
-||ed.2.west.com^
 ||edriving.actonservice.com^
 ||edtrainingcenter.actonservice.com^
 ||education.therapymgmt.com^
-||edward.hrm.healthgrades.com^
 ||elogic-learning.actonservice.com^
 ||em.crownandcaliber.com^
 ||email.allantgroup.com^
@@ -4441,14 +4358,11 @@ charlestownwyllie.oaklawnnonantum.com^
 ||enchantedrock.actonservice.com^
 ||engage.dovetailinsurance.com^
 ||engage.encon.ca^
-||engage.krm22.com^
-||engage.us.victorinsurance.com^
 ||engagement.allegion.com^
 ||enterprisehive.actonservice.com^
 ||enterpriseimaging.agfahealthcare.com^
 ||erepublic.actonservice.com^
 ||essentiahealth.hrm.healthgrades.com^
-||estore.biscoind.com^
 ||eu.sharpmarketing.eu^
 ||eumarketing.sedgwick.com^
 ||exdmarketing.smu.edu.sg^
@@ -4457,14 +4371,11 @@ charlestownwyllie.oaklawnnonantum.com^
 ||expo.nada.org^
 ||fiber.zayo.com^
 ||finley.finleyusa.com^
-||fly.caljetelite.com^
-||fna.fnainsurance.com^
 ||fnbwynne.actonservice.com^
 ||footstepsgroup.actonservice.com^
 ||forms.cooperaerobics.com^
 ||forms.davidrolfs.com^
 ||foxtinfo.foxt.com^
-||fr.lucanet.com^
 ||fr.sharpmarketing.eu^
 ||franchising.pizzapizza.ca^
 ||frankwatching.actonservice.com^
@@ -4475,16 +4386,13 @@ charlestownwyllie.oaklawnnonantum.com^
 ||gassales.eversource.com^
 ||genesishealth.hrm.healthgrades.com^
 ||geonetric.actonservice.com^
-||get.isentia.com^
 ||go.alliancefunds.com^
-||go.biz.uiowa.edu^
 ||go.brandactive.com^
 ||go.brightstarsystems.com^
 ||go.coffeycomm.com^
 ||go.corrus.com^
 ||go.cresa.plantemoran.com^
 ||go.fabplaygrounds.com^
-||go.godunnage.com^
 ||go.hatcocorp.com^
 ||go.hutchmfg.com^
 ||go.isbamutual.com^
@@ -4492,7 +4400,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||go.madisoncollege.edu^
 ||go.matthewsautomation.com^
 ||go.matthewsmarking.com^
-||go.milsoft.com^
 ||go.pri-med.com^
 ||go.tdyne.com^
 ||go.wm.plantemoran.com^
@@ -4503,41 +4410,29 @@ charlestownwyllie.oaklawnnonantum.com^
 ||greencharge.actonservice.com^
 ||guardiancu.actonservice.com^
 ||hackensackumc.hrm.healthgrades.com^
-||hallmarkhealth.hrm.healthgrades.com^
 ||hcacapitaldivision.hrm.healthgrades.com^
 ||hcacentralwesttexas.hrm.healthgrades.com^
-||hcahealthcare.hrm.healthgrades.com^
 ||hcanorthflorida.hrm.healthgrades.com^
-||hcasouthatlantic.hrm.healthgrades.com^
 ||healthonecares.hrm.healthgrades.com^
 ||healthpay24.actonservice.com^
 ||heartland.hrm.healthgrades.com^
 ||hello.emergeinteractive.com^
-||henryford.hrm.healthgrades.com^
-||hu.promo.skf.com^
-||hub.hubfinancial.com^
 ||info.abcnorcal.org^
 ||info.aiabrg.aleragroup.com^
 ||info.aircuity.com^
 ||info.aleragroup.com^
-||info.americanroller.com^
 ||info.archerdx.com^
 ||info.atlastravel.com^
-||info.avantiplc.com^
 ||info.avondixon.aleragroup.com^
-||info.axionbiosystems.com^
 ||info.azuga.com^
-||info.bakercommunications.com^
 ||info.bcn.nl^
 ||info.beaconmedicare.aleragroup.com^
 ||info.belltechlogix.com^
 ||info.bintheredumpthatusa.com^
 ||info.blumshapiro.com^
 ||info.brilliantfs.com^
-||info.bringg.com^
 ||info.burnswhite.com^
 ||info.calnexsol.com^
-||info.capitalonesettlement.com^
 ||info.castlemetals.com^
 ||info.centrak.com^
 ||info.christiancreditcounselors.org^
@@ -4551,16 +4446,13 @@ charlestownwyllie.oaklawnnonantum.com^
 ||info.cranes101.com^
 ||info.cresinsurance.com^
 ||info.critical-logic.com^
-||info.ctg.com^
 ||info.cytosmart.com^
 ||info.dairymaster.com^
 ||info.dataservicesinc.com^
 ||info.dbbest.com^
 ||info.dickerson-group.aleragroup.com^
-||info.dincloud.com^
 ||info.dril-quip.com^
 ||info.duncan-parnell.com^
-||info.duprelogistics.com^
 ||info.e-tabs.com^
 ||info.edriving.com^
 ||info.edtrainingcenter.com^
@@ -4580,10 +4472,8 @@ charlestownwyllie.oaklawnnonantum.com^
 ||info.freedomcte.com^
 ||info.gcgfinancial-aia.aleragroup.com^
 ||info.globalventuring.com^
-||info.goagilix.com^
 ||info.goldmine.com^
 ||info.goodwillgr.org^
-||info.greif.com^
 ||info.groupbenefits.aleragroup.com^
 ||info.growthzone.com^
 ||info.gucu.org^
@@ -4592,7 +4482,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||info.hmk-ins.aleragroup.com^
 ||info.ic3dprinters.com^
 ||info.ielts.com.au^
-||info.imagimob.com^
 ||info.itw-air.com^
 ||info.jacounter.aleragroup.com^
 ||info.jfahern.com^
@@ -4604,12 +4493,8 @@ charlestownwyllie.oaklawnnonantum.com^
 ||info.macro4.com^
 ||info.mactac.com^
 ||info.marketing.spxflow.com^
-||info.marshpcs.com^
-||info.marumatchbox.com^
 ||info.membercoverage.com^
 ||info.micromentor.org^
-||info.motion10.nl^
-||info.multichannelsystems.com^
 ||info.mvp.nl^
 ||info.naag.org^
 ||info.natlenvtrainers.com^
@@ -4623,7 +4508,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||info.parallel6.com^
 ||info.pathwisepartners.com^
 ||info.phionline.com^
-||info.phsmobile.com^
 ||info.pillartopost.com^
 ||info.precisebusiness.com.au^
 ||info.provencut.com^
@@ -4631,25 +4515,20 @@ charlestownwyllie.oaklawnnonantum.com^
 ||info.re-sourcepartners.com^
 ||info.reachtech.com^
 ||info.relphbenefitadvisors.aleragroup.com^
-||info.reltio.com^
 ||info.royaltyroofing.com^
 ||info.safelogic.com^
 ||info.sante-group.com^
 ||info.scoopinsurance.ca^
-||info.scottmadden.com^
-||info.serversdirect.com^
 ||info.shirazi.aleragroup.com^
 ||info.simutechmultimedia.com^
 ||info.singlepath.com^
 ||info.sispartnerplatform.com^
 ||info.skordle.com^
-||info.ststephenpresbyterian.com^
 ||info.summitinvest.com^
 ||info.summitministries.org^
 ||info.superdry-totech.com^
 ||info.suzy.com^
 ||info.unicous.com^
-||info.unimar.com^
 ||info.uptophealth.com^
 ||info.valencepm.com^
 ||info.vaporstream.com^
@@ -4659,37 +4538,24 @@ charlestownwyllie.oaklawnnonantum.com^
 ||info.voxbone.com^
 ||info.w-systems.com^
 ||info.washlaundry.com^
-||info.webinar.nl^
 ||info.wiserhome.com^
 ||info.worldlink-us.com^
-||info.zoominfo-privacy.com^
-||info.zoominfo.io^
 ||info01.on24.com^
 ||infoaction.mimakiusa.com^
 ||infoland.actonservice.com^
 ||inform.milestonegroup.com^
 ||innovation.rlgbuilds.com^
 ||insight.wittkieffer.com^
-||insights.compagnon.com^
-||internalcomms.hubinternational.com^
-||intouch.schlesingerassociates.com^
 ||ipredictus.actonservice.com^
 ||jifflenow.actonservice.com^
-||jp.promo.skf.com^
-||kaweahdelta.hrm.healthgrades.com^
 ||lcscompanies.lcsnet.com^
 ||learn.brightspotstrategy.com^
 ||learn.healthyinteractions.com^
-||learn.openlending.com^
 ||loansales.cbre.com^
 ||lovelace.hrm.healthgrades.com^
-||lp.mnp.ca^
-||lubricationde.promo.skf.com^
-||lubricationus.promo.skf.com^
 ||lydallpm.actonservice.com^
 ||m-m.actonservice.com^
 ||m.evolutiondigital.com^
-||m.transfix.io^
 ||ma.kyloepartners.com^
 ||ma.lexicon.se^
 ||ma.moblrn.com^
@@ -4697,8 +4563,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||ma.mw-ind.com^
 ||ma.preciofishbone.com^
 ||marketing-us.alere.com^
-||marketing.3mark.com^
-||marketing.acadian-asset.com^
 ||marketing.acumenmd.com^
 ||marketing.am.jll.com^
 ||marketing.apexlearning.com^
@@ -4710,14 +4574,11 @@ charlestownwyllie.oaklawnnonantum.com^
 ||marketing.asmarter.window.com^
 ||marketing.assessio.com^
 ||marketing.atcombts.com^
-||marketing.athenago.com^
 ||marketing.attaneresults.com^
 ||marketing.attivoconsulting.com^
 ||marketing.attocube.com^
 ||marketing.balconette.co.uk^
 ||marketing.businesssystemsuk.com^
-||marketing.carlisleit.com^
-||marketing.carltonlanding.com^
 ||marketing.cas-online.com^
 ||marketing.cdsm.co.uk^
 ||marketing.cellarstone.com^
@@ -4728,17 +4589,13 @@ charlestownwyllie.oaklawnnonantum.com^
 ||marketing.cfa.ca^
 ||marketing.championsales.com^
 ||marketing.chathamfinancial.com^
-||marketing.christchurchnz.com^
-||marketing.ciandt.com^
 ||marketing.citadelus.com^
 ||marketing.clarityinc.com^
 ||marketing.clarosanalytics.com^
 ||marketing.clearcareonline.com^
 ||marketing.clickrain.com^
-||marketing.colliers.com^
 ||marketing.cologuardclassic.com^
 ||marketing.couplescruise.com^
-||marketing.cresa.com^
 ||marketing.cyber-edge.com^
 ||marketing.cygnetcloud.com^
 ||marketing.d4discovery.com^
@@ -4747,7 +4604,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||marketing.datamatics.com^
 ||marketing.dataprise.com^
 ||marketing.datasyncsolutions.com^
-||marketing.dcmh.net^
 ||marketing.deckerretirementplanning.com^
 ||marketing.dedicated-db.com^
 ||marketing.destinationvancouver.com^
@@ -4759,28 +4615,19 @@ charlestownwyllie.oaklawnnonantum.com^
 ||marketing.ecosystemintegrity.com^
 ||marketing.ehy.com^
 ||marketing.enlightedinc.com^
-||marketing.entrinsik.com^
 ||marketing.epicbrokers.com^
-||marketing.espec.com^
 ||marketing.evansbank.com^
 ||marketing.ewi.org^
 ||marketing.explorenorthmyrtlebeach.com^
 ||marketing.external.xerox.com^
 ||marketing.ez-newsletters.com^
 ||marketing.farmmarketid.com^
-||marketing.fathomevents.com^
 ||marketing.feiinsurance.com^
 ||marketing.festiva.com^
 ||marketing.festivagetaways.com^
 ||marketing.festo.com^
 ||marketing.finalcode.com^
 ||marketing.five19creative.com^
-||marketing.flsmidth.com^
-||marketing.fwcbd.com^
-||marketing.genesis-fs.com^
-||marketing.getcertain.ca^
-||marketing.getfidelis.com^
-||marketing.goldenpaints.com^
 ||marketing.healthcasts.co^
 ||marketing.hellomedia.com^
 ||marketing.hemsleyfraserdigital.co.uk^
@@ -4809,26 +4656,15 @@ charlestownwyllie.oaklawnnonantum.com^
 ||marketing.insightec.com^
 ||marketing.insigniam.com^
 ||marketing.intrado.com^
-||marketing.inventiconasia.com^
 ||marketing.iongroup.com^
 ||marketing.itsavvy.com^
 ||marketing.iuseelite.com^
 ||marketing.ivctechnologies.com^
 ||marketing.iwsinc.com^
 ||marketing.izeno.com^
-||marketing.jdyoung.com^
-||marketing.johncrane.com^
-||marketing.keylane.com^
-||marketing.liberateit.com^
 ||marketing.lockstate.com^
-||marketing.lumenera.com^
-||marketing.magenta-technology.com^
-||marketing.marineagency.com^
-||marketing.mattersmost.nl^
 ||marketing.mba.hkust.edu.hk^
-||marketing.medical.averydennison.com^
 ||marketing.medsphere.com^
-||marketing.meetac.com^
 ||marketing.mhe-demag.com^
 ||marketing.mrcaff.org^
 ||marketing.mwb.com^
@@ -4854,18 +4690,13 @@ charlestownwyllie.oaklawnnonantum.com^
 ||marketing.on1.com^
 ||marketing.optimeconsulting.com^
 ||marketing.optimumenergyco.com^
-||marketing.paper-leaf.com^
 ||marketing.pax8.com^
-||marketing.peerapp.com^
 ||marketing.peoplesafe.co.uk^
 ||marketing.petrolad.com^
 ||marketing.potlatchdelticlandsales.com^
-||marketing.prep101.com^
 ||marketing.processmaker.com^
-||marketing.protecdirect.co.uk^
 ||marketing.puretechltd.com^
 ||marketing.quenchonline.com^
-||marketing.quonticbank.com^
 ||marketing.realcomm.com^
 ||marketing.realresultsmarketing.com^
 ||marketing.realstorygroup.com^
@@ -4877,12 +4708,9 @@ charlestownwyllie.oaklawnnonantum.com^
 ||marketing.roinnovation.com^
 ||marketing.ruckuswireless.com^
 ||marketing.sap.events.deloitte.com^
-||marketing.schneiderdowns.com^
 ||marketing.seclore.com^
-||marketing.sectra.com^
 ||marketing.securakey.com^
 ||marketing.securew2.com^
-||marketing.seeclearfield.com^
 ||marketing.self-helpfcu.org^
 ||marketing.sensysgatso.com^
 ||marketing.serifsf.com^
@@ -4891,43 +4719,29 @@ charlestownwyllie.oaklawnnonantum.com^
 ||marketing.sojern.com^
 ||marketing.solarcentury.com^
 ||marketing.soloprotect.com^
-||marketing.sourceadvisors.com^
-||marketing.spireseattle.com^
-||marketing.stamen.com^
 ||marketing.stampdestinationmarketing.com^
 ||marketing.sterlingsolutions.com^
 ||marketing.supercolor.com^
 ||marketing.superiormobilemedics.com^
-||marketing.surfcityusa.com^
 ||marketing.swiftprepaid.com^
-||marketing.teaminx.com^
 ||marketing.teamspirit.uk.com^
 ||marketing.techdata.com.techdatamarketing.com^
 ||marketing.tourismsaskatoon.com^
 ||marketing.translations.com^
 ||marketing.unionhousesf.com^
-||marketing.uoficreditunion.org^
 ||marketing.vetdnacenter.com^
-||marketing.vgmhomelink.com^
 ||marketing.vippetcare.com^
 ||marketing.visailing.com^
 ||marketing.visitbellevuewa.com^
 ||marketing.visitbgky.com^
 ||marketing.visitchesapeake.com^
 ||marketing.visitchicagosouthland.com^
-||marketing.visitcorpuschristi.com^
-||marketing.visitlex.com^
-||marketing.visitmusiccity.com^
 ||marketing.visitsalisburync.com^
 ||marketing.visitspokane.com^
-||marketing.visualskus.com^
 ||marketing.viwoinc.com^
 ||marketing.waltonsignage.com^
 ||marketing.welchllp.com^
-||marketing.wesco.com.br^
 ||marketing.wintonhomes.ca^
-||marketing.woodtone.com^
-||marketing.wwfi.com^
 ||marketing.ytc.com^
 ||marketing.zayo.com^
 ||marketing.zenecosystems.com^
@@ -4952,24 +4766,17 @@ charlestownwyllie.oaklawnnonantum.com^
 ||mktg.alphawire.com^
 ||mktg.exagoinc.com^
 ||mktg.matssoft.com^
-||mktg.pershing.com^
 ||mktg.picarro.com^
-||mktg.rocklandmfg.com^
 ||mktg.ummhealth.org^
-||mm.morrellinc.com^
 ||moody.actonsoftware.com^
 ||morganfranklin.actonservice.com^
-||motiontechnologies.promo.skf.com^
-||msbainfo.fbe.hku.hk^
 ||mshs.actonservice.com^
 ||mw-ind.actonservice.com^
 ||nakanohito.jp^
 ||news.djcoregon.com^
 ||news.lvb.com^
-||news.strategiccfo360.com^
 ||news.verimatrix.com^
 ||nimbler.actonservice.com^
-||nordic.promo.skf.com^
 ||now.tana.fi^
 ||now.taskus.com^
 ||olivia.actonservice.com^
@@ -4977,24 +4784,16 @@ charlestownwyllie.oaklawnnonantum.com^
 ||opus.2lifecommunities.org^
 ||outreach.successforall.org^
 ||outreach.veritivcorp.com^
-||overlakemedicalcenter.hrm.healthgrades.com^
 ||page.downloads.cooperlighting.com^
 ||page.oceaninsight.com^
 ||pages.crd.com^
 ||pages.distributionstrategy.com^
 ||pages.jobaline.com^
 ||pages.telemessage.com^
-||palmettohealth.hrm.healthgrades.com^
 ||pasco.actonservice.com^
-||personal.hubinternational.com^
-||ph.roturadepantalla.com^
 ||phdinc.actonservice.com^
 ||pimpoint.inriver.com^
-||pinnacleuniversity.hrm.healthgrades.com^
-||pl.sharpmarketing.eu^
-||privateclient.hubinternational.com^
 ||pro.6arry.com^
-||profile-update.healthgrades.com^
 ||programs.willis.com^
 ||promotions.501c3.org^
 ||prowareness.actonservice.com^
@@ -5010,36 +4809,25 @@ charlestownwyllie.oaklawnnonantum.com^
 ||reactioncommerce.actonservice.com^
 ||redstagfulfillment.actonservice.com^
 ||releasd.actonservice.com^
-||remarketing.oncourselearning.com^
-||resources.acarasolutions.com^
 ||resources.activatems.com^
 ||resources.faronics.com^
-||resources.talentrise.com^
 ||revgroup.actonservice.com^
 ||rewards.parago.com^
 ||riversidehealthcare.hrm.healthgrades.com^
-||riverview.hrm.healthgrades.com^
 ||rollbar.actonservice.com^
-||rs.promo.skf.com^
 ||rsvp.markettraders.com^
 ||rushmemorial.hrm.healthgrades.com^
-||russia.promo.skf.com^
-||sa.bdoaustralia.bdo.com.au^
 ||saint-lukes.hrm.healthgrades.com^
 ||samarketing.sedgwick.com^
 ||schlesingerassociates.actonservice.com^
 ||scispg.smu.edu.sg^
-||scmarketing.colliers.com^
-||seals.promo.skf.com^
 ||seb.sharpmarketing.eu^
-||sedgwickpooling.sedgwick.com^
 ||seniorliving.aberdeenridge.pmma.org^
 ||seniorliving.artisseniorliving.com^
 ||seniorliving.casadelascampanas.com^
 ||seniorliving.friendshipvillageaz.com^
 ||seniorliving.jkv.org^
 ||seniorliving.mrcaff.org^
-||seniorliving.sagewoodlcs.com^
 ||seniorliving.theheritagelcs.com^
 ||seniorliving.thewoodlandsatfurman.org^
 ||seniorliving.welcometomonarchlanding.com^
@@ -5047,7 +4835,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||seniorliving.whitneycenter.com^
 ||services.datotel.com^
 ||services.reworkbyroe.com^
-||servicesandsolutions.promo.skf.com^
 ||servicing.unitedautocredit.net^
 ||sffirecu.actonservice.com^
 ||sg.lucanet.com^
@@ -5067,17 +4854,13 @@ charlestownwyllie.oaklawnnonantum.com^
 ||southbeachlady.actonservice.com^
 ||southcoast.hrm.healthgrades.com^
 ||spa.admissions.ucdenver.edu^
-||spandaupumpen.promo.skf.com^
 ||srglobal.actonservice.com^
 ||srsa.srglobal.com^
-||srsg.srglobal.com^
 ||ssfllp.actonservice.com^
 ||start.ashfieldmeetings.com^
-||start.mybillingtree.com^
 ||start.stemhealthcare.com^
 ||stcharleshealthcare.hrm.healthgrades.com^
 ||studentadvantage.actonservice.com^
-||success.ebmsoftware.com^
 ||success.emilygriffith.edu^
 ||success.mapcom.com^
 ||success.rhb.com^
@@ -5086,12 +4869,10 @@ charlestownwyllie.oaklawnnonantum.com^
 ||symbio.actonservice.com^
 ||system.nefiber.com^
 ||systempavers.actonservice.com^
-||team.moxtra.com^
 ||tebu-bio.actonservice.com^
 ||tech.opengear.com^
 ||tentflooring.biljax.com^
 ||thebdx.actonservice.com^
-||thechristhospital.hrm.healthgrades.com^
 ||thetrainers.actonservice.com^
 ||think-it.avnet.com^
 ||tongue-tied-nw.actonservice.com^
@@ -5100,46 +4881,32 @@ charlestownwyllie.oaklawnnonantum.com^
 ||triconah.actonservice.com^
 ||truefaced.actonservice.com^
 ||trueoffice.actonservice.com^
-||tw.promo.skf.com^
 ||tyrens.actonservice.com^
 ||u4.unit4.com^
 ||uaemarketing.sedgwick.com^
 ||uhhospitals.hrm.healthgrades.com^
 ||ukmarketing.communications.episerver.com^
-||umassmemorial.hrm.healthgrades.com^
-||unchealthcare.hrm.healthgrades.com^
 ||upfrontbd.actonservice.com^
 ||us-marketing.festo.com^
 ||usb-vna.coppermountaintech.com^
-||vehicleaftermarket.eus.promo.skf.com^
 ||veoci.actonservice.com^
-||vietnam.promo.skf.com^
 ||visailing.actonservice.com^
 ||visit.monroecollege.edu^
 ||voiply.actonservice.com^
 ||voltdeltainfo.voltdelta.com^
 ||vonazon.actonservice.com^
-||vsmeue.promo.skf.com^
-||vsmeus.promo.skf.com^
-||vsmnam.promo.skf.com^
-||web.yourerc.com^
-||welcome.hubinternational.com^
 ||welcome.patientmatters.com^
 ||westevents.presidio.com^
 ||woodtone.actonservice.com^
 ||worldleaderssales.actonservice.com^
 ||ww.oakwoodsys.com^
-||www.bmi.marketing-bmiimaging.com^
-||www.business.royal-cars.com^
 ||www.cloud.trapptechnology.com^
 ||www.globalinfoportal.com^
-||www.gogreen.hyliion.com^
 ||www.marketing-bmiimaging.com^
 ||www.marketing.linguamatics.com^
 ||www.paydashboardinfo.com^
 ||www.techservices.trapptechnology.com^
 ||www1.drwilsons.com^
-||www1.mcsrentalsoftware.com^
 ||www1.symmons.com^
 ||www1.zoominfo.com^
 ||www2.bobcad.com^
@@ -5336,7 +5103,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||metrics.angieslist.com^
 ||metrics.ansys.com^
 ||metrics.apartmentfinder.com^
-||metrics.apartments.com^
 ||metrics.armstrong.com^
 ||metrics.audi.co.uk^
 ||metrics.autobytel.com^
@@ -5543,11 +5309,8 @@ charlestownwyllie.oaklawnnonantum.com^
 ||os.mbox.com.au^
 ||os.send2fax.com^
 ||p1.danskebank.co.uk^
-||p2.p2.danskebank.dk^
-||p3.p2.danskebank.dk^
 ||peak.patagonia.com^
 ||peaks.patagonia.com^
-||plansponsor.com.102.122.207.net^
 ||qomnit.equinox.com^
 ||s.boydgaming.com^
 ||s.fitchratings.com^
@@ -6067,8 +5830,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! sc.omtrdc.net disguised trackers
 !
-||000scripps.hb.omtrdc.net^
-||3minc.tt.hb-fa-stage.omtrdc.net^
 ||a.publicmobile.ca^
 ||aa-metrics.airpayment.jp^
 ||aa-metrics.airregi.jp^
@@ -6085,7 +5846,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||abmeldung.information.whatsappsim.de^
 ||adobeanalytics-http.hds.com^
 ||adobeanalytics.gettinghired.com^
-||adobedc.demdex.net^
 ||analytic.americanfunds.com^
 ||analytics.boxlunch.com^
 ||analytics.budget.se^
@@ -6355,7 +6115,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||metrics.ocrelizumabinfo.com^
 ||metrics.olgaintimates.com^
 ||metrics.orvis.com^
-||metrics.pacsun.com^
 ||metrics.pagoda.com^
 ||metrics.panasonic.jp^
 ||metrics.pandora.com^
@@ -6692,7 +6451,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||smetrics.maritimeintelligence.informa.com^
 ||smetrics.markandgraham.com^
 ||smetrics.marksandspencer.com^
-||smetrics.marriott.com^
 ||smetrics.marshalls.com^
 ||smetrics.marshandmclennan.com^
 ||smetrics.mastercard.com^
@@ -6750,7 +6508,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||smetrics.nesn.com^
 ||smetrics.newark.com^
 ||smetrics.newfoundlandgrocerystores.ca^
-||smetrics.nfl.com^
 ||smetrics.ni.com^
 ||smetrics.nielsen.com^
 ||smetrics.nofrills.ca^
@@ -6899,7 +6656,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||smetrics.saksoff5th.com^
 ||smetrics.salliemae.com^
 ||smetrics.salomon.com^
-||smetrics.samsung.com^
 ||smetrics.samsunglife.com^
 ||smetrics.santander.co.uk^
 ||smetrics.sap.com^
@@ -6911,7 +6667,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||smetrics.sazerac.com^
 ||smetrics.sazerachouse.com^
 ||smetrics.sbisec.co.jp^
-||smetrics.sbs.com.au^
 ||smetrics.scandichotels.com^
 ||smetrics.scandichotels.de^
 ||smetrics.scandichotels.dk^
@@ -7093,7 +6848,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||smetrics.tyson.com^
 ||smetrics.u-can.co.jp^
 ||smetrics.ubi.com^
-||smetrics.uhc.com^
 ||smetrics.unipolsai.it^
 ||smetrics.upc.ch^
 ||smetrics.ups.com^
@@ -7325,7 +7079,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||ssl.o.univadis.fr^
 ||ssl.o.univadis.it^
 ||ssl.o.vitals.com^
-||ssl.o.webmd.com^
 ||sslsc.sanitas.com^
 ||sslstats.canadapost-postescanada.ca^
 ||sslstats.canadapost.ca^
@@ -7333,7 +7086,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||ssmr.so-net.ne.jp^
 ||ssmr2.so-net.ne.jp^
 ||sstatistikk.telenor.no^
-||sstats.adobe.com^
 ||sstats.alfa.com^
 ||sstats.allure.com^
 ||sstats.americafirst.com^
@@ -7500,7 +7252,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! mboxedge37-02.tt.omtrdc.net disguised trackers
 !
-||abt.bauhaus.info^
 ||abt.nike.com^
 ||dii3.zooplus.nl^
 ||dm-target.fishersci.com^
@@ -7534,301 +7285,60 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! mboxedge37-alb02.tt.omtrdc.net disguised trackers
 !
-||abt.bauhaus.info^
-||abt.nike.com^
-||dii3.zooplus.nl^
-||dm-target.fishersci.com^
 ||experience.amp.co.nz^
-||experience.fbbrands.com^
-||optimisation.coop.co.uk^
-||purpose.maxizoo.ie^
-||samt.zkb.ch^
-||satgt.grafana.com^
-||starget.airmiles.ca^
-||starget.collegeboard.org^
-||starget.vodafone.es^
-||starget.westjet.com^
-||stt.cpaaustralia.com.au^
 ||stt.grace.com^
-||sxp.allianz.de^
-||target-omtrdc.deka.de^
 ||target.amica.com^
-||target.changehealthcare.com^
-||target.footlocker.com.au^
-||target.hsn.com^
-||target.key.com^
-||target.nxp.com^
-||target.questdiagnostics.com^
-||target.sivasdescalzo.com^
-||target.sportsmansguide.com^
-||target.vwfs.ie^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.astrogaming.com^
-||webtarget.logicool.co.jp^
-||webtarget.logitech.com^
 ||webtarget.logitech.com.cn^
-||webtarget.logitechg.com^
 !
 ! mboxedge38-02.tt.omtrdc.net disguised trackers
 !
-||abt.bauhaus.info^
-||abt.nike.com^
-||dm-target.fishersci.com^
 ||dxop.bcbsla.com^
-||optimisation.coop.co.uk^
-||satgt.grafana.com^
-||starget.collegeboard.org^
-||starget.westjet.com^
 ||stmetrics.bbva.pe^
-||stt.cpaaustralia.com.au^
-||target.changehealthcare.com^
-||target.footlocker.com.au^
-||target.hsn.com^
-||target.nxp.com^
-||target.questdiagnostics.com^
-||target.sivasdescalzo.com^
-||target.sportsmansguide.com^
 ||target.stanfordchildrens.org^
 ||target.sunlife.com^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.logitech.com^
-||webtarget.logitech.com.cn^
-||webtarget.logitechg.com^
 !
 ! mboxedge38-alb02.tt.omtrdc.net disguised trackers
 !
-||abt.bauhaus.info^
-||abt.nike.com^
-||dm-target.fishersci.com^
-||dxop.bcbsla.com^
-||optimisation.coop.co.uk^
-||satgt.grafana.com^
-||starget.collegeboard.org^
-||starget.westjet.com^
-||stmetrics.bbva.pe^
-||stt.cpaaustralia.com.au^
-||target.changehealthcare.com^
-||target.footlocker.com.au^
-||target.hsn.com^
-||target.nxp.com^
-||target.questdiagnostics.com^
-||target.sivasdescalzo.com^
-||target.sportsmansguide.com^
-||target.stanfordchildrens.org^
-||target.sunlife.com^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.logitech.com^
-||webtarget.logitech.com.cn^
-||webtarget.logitechg.com^
 !
 ! mboxedge31-02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||dm-target.fishersci.com^
-||satgt.grafana.com^
-||starget.airmiles.ca^
-||starget.collegeboard.org^
-||starget.westjet.com^
-||target.footlocker.com.au^
-||target.hsn.com^
-||target.sivasdescalzo.com^
-||targetlr.adobe.com^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 !
 ! mboxedge31-alb02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||dm-target.fishersci.com^
-||satgt.grafana.com^
-||starget.airmiles.ca^
-||starget.collegeboard.org^
-||starget.westjet.com^
-||target.footlocker.com.au^
-||target.hsn.com^
-||target.sivasdescalzo.com^
-||targetlr.adobe.com^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 !
 ! mboxedge32-02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||dm-target.fishersci.com^
-||experience.fbbrands.com^
-||satgt.grafana.com^
-||starget.collegeboard.org^
-||starget.vodafone.es^
-||target.nxp.com^
-||target.sivasdescalzo.com^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.logicool.co.jp^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 ||webtarget.logitechg.com.cn^
 !
 ! mboxedge32-alb02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||dm-target.fishersci.com^
-||experience.fbbrands.com^
-||satgt.grafana.com^
-||starget.collegeboard.org^
-||starget.vodafone.es^
-||target.nxp.com^
-||target.sivasdescalzo.com^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.logicool.co.jp^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
-||webtarget.logitechg.com.cn^
 !
 ! mboxedge34-02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
 ||demo3.management.testandtarget.omniture.com^
-||dii3.zooplus.nl^
-||dm-target.fishersci.com^
-||experience.fbbrands.com^
-||optimisation.coop.co.uk^
-||satgt.grafana.com^
-||starget.airmiles.ca^
-||starget.collegeboard.org^
-||starget.vodafone.es^
-||starget.westjet.com^
 ||stmetrics.bbva.mx^
-||stt.cpaaustralia.com.au^
-||sxp.allianz.de^
 ||target.champssports.ca^
-||target.changehealthcare.com^
-||target.footlocker.com.au^
-||target.hsn.com^
-||target.key.com^
-||target.nxp.com^
-||target.questdiagnostics.com^
 ||target.sgproof.com^
-||target.sivasdescalzo.com^
-||target.sportsmansguide.com^
 ||target.sunlifeglobalinvestments.com^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.astrogaming.com^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 !
 ! mboxedge34-alb02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||demo3.management.testandtarget.omniture.com^
-||dii3.zooplus.nl^
-||dm-target.fishersci.com^
-||experience.fbbrands.com^
-||optimisation.coop.co.uk^
-||satgt.grafana.com^
-||starget.airmiles.ca^
-||starget.collegeboard.org^
-||starget.vodafone.es^
-||starget.westjet.com^
-||stmetrics.bbva.mx^
-||stt.cpaaustralia.com.au^
-||sxp.allianz.de^
-||target.champssports.ca^
-||target.changehealthcare.com^
-||target.footlocker.com.au^
-||target.hsn.com^
-||target.key.com^
-||target.nxp.com^
-||target.questdiagnostics.com^
-||target.sgproof.com^
-||target.sivasdescalzo.com^
-||target.sportsmansguide.com^
-||target.sunlifeglobalinvestments.com^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.astrogaming.com^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 !
 ! mboxedge35-02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||dii3.zooplus.nl^
-||dm-target.fishersci.com^
-||experience.fbbrands.com^
-||satgt.grafana.com^
-||starget.collegeboard.org^
-||starget.westjet.com^
 ||stmetrics.bbva.com.co^
-||target.changehealthcare.com^
-||target.hsn.com^
-||target.key.com^
-||target.questdiagnostics.com^
-||target.sgproof.com^
-||target.sportsmansguide.com^
-||target.sunlifeglobalinvestments.com^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.astrogaming.com^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 !
 ! mboxedge35-alb02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||dii3.zooplus.nl^
-||dm-target.fishersci.com^
-||experience.fbbrands.com^
-||satgt.grafana.com^
-||starget.collegeboard.org^
-||starget.westjet.com^
-||stmetrics.bbva.com.co^
-||target.changehealthcare.com^
-||target.hsn.com^
-||target.key.com^
-||target.questdiagnostics.com^
-||target.sgproof.com^
-||target.sportsmansguide.com^
-||target.sunlifeglobalinvestments.com^
-||targetlr.adobe.com^
-||ttarget.eastwestbank.com^
-||webtarget.astrogaming.com^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 !
 ! mboxedge36-02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||experience.fbbrands.com^
-||satgt.grafana.com^
-||starget.collegeboard.org^
-||stt.cpaaustralia.com.au^
-||target.footlocker.com.au^
-||targetlr.adobe.com^
-||webtarget.astrogaming.com^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 !
 ! mboxedge36-alb02.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
-||experience.fbbrands.com^
-||satgt.grafana.com^
-||starget.collegeboard.org^
-||stt.cpaaustralia.com.au^
-||target.footlocker.com.au^
-||targetlr.adobe.com^
-||webtarget.astrogaming.com^
-||webtarget.logitech.com^
-||webtarget.logitechg.com^
 !
 ! nike.tt.omtrdc.net disguised trackers
 !
-||abt.nike.com^
 !
 ! futbolclubbarcelona.tt.omtrdc.net disguised trackers
 !
@@ -7837,8 +7347,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! mboxedge34-alb.tt.omtrdc.net disguised trackers
 !
-||adtarget.barcainnovationhub.com^
-||adtarget.fcbarcelona.cat^
 ||assets2.suncorp.com.au^
 ||at.postbank.de^
 ||mbox.wegmans.com^
@@ -7883,132 +7391,27 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! mboxedge34.tt.omtrdc.net disguised trackers
 !
-||adtarget.barcainnovationhub.com^
-||adtarget.fcbarcelona.cat^
-||assets2.suncorp.com.au^
-||at.postbank.de^
-||mbox.wegmans.com^
-||mcdmetrics2.aaa.com^
-||metrics-target.siriusxm.com^
-||sats.spiegel.de^
-||sjourney.penfed.org^
-||spersonalization.mrappliance.com^
-||spersonalization.rainbowintl.com^
-||starget.intel.cn^
-||starget.intel.co.kr^
-||starget.intel.com.br^
-||starget.intel.es^
-||starget.intel.fr^
-||starget.intel.la^
-||starget.intel.ru^
-||starget.panerabread.com^
-||starget.ticketsatwork.com^
-||stt.thelott.com^
-||t.nordea.fi^
-||target.bcbsnd.com^
-||target.caixabank.es^
-||target.chrysler.com^
-||target.comenity.net^
-||target.fiatusa.com^
-||target.footlocker.ca^
-||target.footlocker.co.uk^
-||target.footlocker.es^
-||target.footlocker.pt^
-||target.groupama.fr^
-||target.hyundaiusa.com^
-||target.intact.ca^
-||target.intactinsurance.com^
-||target.michaels.com^
-||target.newark.com^
-||target.premierinn.com^
-||target.publicissapient.com^
-||target.sunlife.com.ph^
-||target.thetruth.com^
-||target.zeiss.de^
-||targetsecure.kohler.com^
 !
 ! mboxedge35-alb.tt.omtrdc.net disguised trackers
 !
-||adtarget.barcainnovationhub.com^
-||at.postbank.de^
-||mbox.wegmans.com^
-||mcdmetrics2.aaa.com^
-||metrics-target.siriusxm.com^
 ||purpose.maxizoo.be^
-||sats.spiegel.de^
-||sjourney.penfed.org^
-||starget.intel.cn^
-||starget.intel.co.kr^
 ||starget.intel.de^
-||starget.intel.es^
-||starget.intel.la^
-||starget.intel.ru^
 ||starget.ladbrokes.be^
-||starget.panerabread.com^
 ||starget.plumbenefits.com^
-||starget.ticketsatwork.com^
 ||starget.workingadvantage.com^
-||stt.thelott.com^
 ||target.base.be^
-||target.caixabank.es^
-||target.chrysler.com^
-||target.fiatusa.com^
 ||target.footlocker.be^
-||target.intact.ca^
-||target.newark.com^
 ||target.nrma.com.au^
-||target.publicissapient.com^
-||target.sunlife.com.ph^
 ||target.synergy.net.au^
 ||target.telenet.be^
-||target.thetruth.com^
 ||target.vwfs.mx^
-||targetsecure.kohler.com^
 ||tt.ubs.com^
 !
 ! mboxedge35.tt.omtrdc.net disguised trackers
 !
-||adtarget.barcainnovationhub.com^
-||at.postbank.de^
-||mbox.wegmans.com^
-||mcdmetrics2.aaa.com^
-||metrics-target.siriusxm.com^
-||purpose.maxizoo.be^
-||sats.spiegel.de^
-||sjourney.penfed.org^
-||starget.intel.cn^
-||starget.intel.co.kr^
-||starget.intel.de^
-||starget.intel.es^
-||starget.intel.la^
-||starget.intel.ru^
-||starget.ladbrokes.be^
-||starget.panerabread.com^
-||starget.plumbenefits.com^
-||starget.ticketsatwork.com^
-||starget.workingadvantage.com^
-||stt.thelott.com^
-||target.base.be^
-||target.caixabank.es^
-||target.chrysler.com^
-||target.fiatusa.com^
-||target.footlocker.be^
-||target.intact.ca^
-||target.newark.com^
-||target.nrma.com.au^
-||target.publicissapient.com^
-||target.sunlife.com.ph^
-||target.synergy.net.au^
-||target.telenet.be^
-||target.thetruth.com^
-||target.vwfs.mx^
-||targetsecure.kohler.com^
-||tt.ubs.com^
 !
 ! mboxedge37-alb.tt.omtrdc.net disguised trackers
 !
-||adtarget.barcainnovationhub.com^
-||adtarget.fcbarcelona.cat^
 ||adtarget.fcbarcelona.co.it^
 ||adtarget.fcbarcelona.jp^
 ||assets2.aainsurance.co.nz^
@@ -8016,83 +7419,53 @@ charlestownwyllie.oaklawnnonantum.com^
 ||assets2.apia.com.au^
 ||assets2.bingle.com.au^
 ||assets2.gio.com.au^
-||assets2.suncorp.com.au^
 ||at.bhw.de^
 ||at.db-finanzberatung.de^
 ||at.maxblue.de^
 ||at.norisbank.de^
-||at.postbank.de^
 ||contoso-my.sharepoint.com^
 ||experience.asb.co.nz^
 ||experiences.cibc.com^
 ||mbox.offermatica.com^
-||mbox.wegmans.com^
 ||mbox6.offermatica.com^
 ||mbox9.offermatica.com^
 ||mbox9e.offermatica.com^
-||mcdmetrics2.aaa.com^
-||metrics-target.siriusxm.com^
 ||purpose.fressnapf.at^
 ||purpose.fressnapf.de^
-||purpose.maxizoo.be^
 ||purpose.maxizoo.fr^
 ||purpose.maxizoo.pl^
 ||sabxt.teeoff.com^
-||sats.spiegel.de^
-||sjourney.penfed.org^
 ||spersonalization.mrappliance.ca^
 ||spersonalization.neighborly.com^
-||starget.intel.cn^
 ||starget.intel.co.jp^
 ||starget.intel.com.au^
-||starget.intel.com.br^
 ||starget.intel.com.tr^
 ||starget.intel.com.tw^
-||starget.intel.de^
-||starget.intel.es^
-||starget.intel.fr^
 ||starget.intel.it^
-||starget.intel.la^
 ||starget.intel.pl^
-||starget.intel.ru^
-||starget.ladbrokes.be^
 ||starget.nabtrade.com.au^
-||starget.panerabread.com^
-||starget.plumbenefits.com^
-||starget.ticketsatwork.com^
 ||starget.tv2.dk^
-||starget.workingadvantage.com^
 ||stnt.sky.at^
 ||stnt.sky.de^
 ||stt.greencrossvets.com.au^
 ||stt.petbarn.com.au^
 ||stt.tab.com.au^
-||stt.thelott.com^
 ||stt.tyro.com^
 ||t.nordea.dk^
-||t.nordea.fi^
 ||t.nordea.no^
 ||t.nordea.se^
 ||target-test.cisco.com^
 ||target.allianz.ch^
-||target.base.be^
 ||target.bd.dk^
 ||target.bpbusinesssolutions.com^
-||target.caixabank.es^
-||target.chrysler.com^
 ||target.css.ch^
 ||target.elvia.ch^
 ||target.eon.de^
-||target.fiatusa.com^
 ||target.fleetcardsusa.com^
 ||target.footlocker.at^
-||target.footlocker.be^
-||target.footlocker.ca^
-||target.footlocker.co.uk^
 ||target.footlocker.cz^
 ||target.footlocker.de^
 ||target.footlocker.dk^
-||target.footlocker.es^
 ||target.footlocker.fr^
 ||target.footlocker.gr^
 ||target.footlocker.hu^
@@ -8101,27 +7474,14 @@ charlestownwyllie.oaklawnnonantum.com^
 ||target.footlocker.lu^
 ||target.footlocker.no^
 ||target.footlocker.pl^
-||target.footlocker.pt^
 ||target.footlocker.se^
 ||target.fuelman.com^
-||target.groupama.fr^
-||target.intact.ca^
-||target.intactinsurance.com^
-||target.michaels.com^
-||target.newark.com^
 ||target.prd.base.be^
-||target.premierinn.com^
-||target.publicissapient.com^
-||target.sunlife.com.ph^
-||target.telenet.be^
-||target.thetruth.com^
 ||target.vwfs.cz^
 ||target.vwfs.de^
 ||target.vwfs.es^
 ||target.vwfs.fr^
-||targetsecure.kohler.com^
 ||tt.sj.se^
-||tt.ubs.com^
 ||tt.ulsterbank.co.uk^
 ||tt.ulsterbank.ie^
 ||www4s.ing.be^
@@ -8130,266 +7490,42 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! mboxedge37.tt.omtrdc.net disguised trackers
 !
-||adtarget.barcainnovationhub.com^
-||adtarget.fcbarcelona.cat^
-||at.db-finanzberatung.de^
-||at.maxblue.de^
-||at.norisbank.de^
-||at.postbank.de^
-||experience.asb.co.nz^
-||mbox.wegmans.com^
-||mbox6.offermatica.com^
-||mcdmetrics2.aaa.com^
-||metrics-target.siriusxm.com^
-||purpose.fressnapf.at^
-||purpose.fressnapf.de^
-||purpose.maxizoo.be^
-||purpose.maxizoo.fr^
-||purpose.maxizoo.pl^
-||sabxt.teeoff.com^
-||sats.spiegel.de^
-||sjourney.penfed.org^
-||spersonalization.neighborly.com^
-||starget.intel.cn^
-||starget.intel.co.jp^
-||starget.intel.com.au^
-||starget.intel.com.br^
-||starget.intel.com.tr^
-||starget.intel.de^
-||starget.intel.es^
-||starget.intel.fr^
-||starget.intel.it^
-||starget.intel.la^
-||starget.intel.pl^
-||starget.intel.ru^
-||starget.ladbrokes.be^
-||starget.panerabread.com^
-||starget.plumbenefits.com^
-||starget.ticketsatwork.com^
-||starget.tv2.dk^
-||starget.workingadvantage.com^
-||stnt.sky.at^
-||stnt.sky.de^
-||t.nordea.dk^
-||t.nordea.fi^
-||t.nordea.no^
-||t.nordea.se^
 ||target.aia.co.kr^
-||target.allianz.ch^
-||target.base.be^
-||target.bd.dk^
-||target.bpbusinesssolutions.com^
-||target.caixabank.es^
-||target.chrysler.com^
-||target.css.ch^
-||target.elvia.ch^
-||target.eon.de^
-||target.fiatusa.com^
-||target.footlocker.at^
-||target.footlocker.be^
-||target.footlocker.ca^
-||target.footlocker.co.uk^
-||target.footlocker.cz^
-||target.footlocker.de^
-||target.footlocker.dk^
-||target.footlocker.es^
-||target.footlocker.fr^
-||target.footlocker.gr^
-||target.footlocker.hu^
-||target.footlocker.ie^
-||target.footlocker.it^
-||target.footlocker.no^
-||target.footlocker.pl^
-||target.footlocker.pt^
-||target.footlocker.se^
-||target.fuelman.com^
-||target.groupama.fr^
-||target.intactinsurance.com^
-||target.michaels.com^
-||target.newark.com^
-||target.prd.base.be^
-||target.premierinn.com^
-||target.publicissapient.com^
-||target.sunlife.com.ph^
-||target.telenet.be^
-||target.thetruth.com^
-||target.vwfs.cz^
-||target.vwfs.de^
-||target.vwfs.es^
-||target.vwfs.fr^
-||targetsecure.kohler.com^
-||tt.sj.se^
-||tt.ubs.com^
-||tt.ulsterbank.co.uk^
-||tt.ulsterbank.ie^
-||xps.huk.de^
-||xps.huk24.de^
 !
 ! mboxedge38-alb.tt.omtrdc.net disguised trackers
 !
-||adtarget.barcainnovationhub.com^
-||assets2.suncorp.com.au^
-||at.postbank.de^
-||experience.asb.co.nz^
-||mcdmetrics2.aaa.com^
-||purpose.fressnapf.de^
-||sats.spiegel.de^
-||sjourney.penfed.org^
-||starget.intel.cn^
-||starget.intel.com.tr^
-||starget.intel.com.tw^
-||starget.intel.de^
-||starget.intel.es^
-||starget.intel.ru^
-||starget.ladbrokes.be^
-||stt.tab.com.au^
-||t.nordea.fi^
 ||target.abanca.com^
-||target.base.be^
-||target.caixabank.es^
-||target.chrysler.com^
-||target.fiatusa.com^
-||target.footlocker.co.uk^
-||target.footlocker.fr^
-||target.footlocker.lu^
-||target.groupama.fr^
-||target.newark.com^
-||target.premierinn.com^
-||target.publicissapient.com^
 ||target.sunlife.co.id^
 ||target.sunlife.com.hk^
-||target.sunlife.com.ph^
-||target.telenet.be^
-||targetsecure.kohler.com^
-||tt.ulsterbank.co.uk^
-||xps.huk.de^
 !
 ! mboxedge38.tt.omtrdc.net disguised trackers
 !
-||adtarget.barcainnovationhub.com^
-||assets2.suncorp.com.au^
-||at.postbank.de^
-||experience.asb.co.nz^
-||mcdmetrics2.aaa.com^
-||purpose.fressnapf.de^
-||sats.spiegel.de^
-||sjourney.penfed.org^
-||starget.intel.cn^
-||starget.intel.com.tr^
-||starget.intel.com.tw^
-||starget.intel.de^
-||starget.intel.es^
-||starget.intel.ru^
-||starget.ladbrokes.be^
-||stt.tab.com.au^
-||t.nordea.fi^
-||target.abanca.com^
-||target.base.be^
-||target.caixabank.es^
-||target.chrysler.com^
-||target.fiatusa.com^
-||target.footlocker.co.uk^
-||target.footlocker.fr^
-||target.footlocker.lu^
-||target.groupama.fr^
-||target.newark.com^
-||target.premierinn.com^
-||target.publicissapient.com^
-||target.sunlife.co.id^
-||target.sunlife.com.hk^
-||target.sunlife.com.ph^
-||target.telenet.be^
-||targetsecure.kohler.com^
-||tt.ulsterbank.co.uk^
-||xps.huk.de^
 !
 ! mboxedge31-alb.tt.omtrdc.net disguised trackers
 !
-||experience.asb.co.nz^
-||metrics-target.siriusxm.com^
-||starget.intel.la^
-||starget.panerabread.com^
-||target.base.be^
-||target.chrysler.com^
-||target.footlocker.pt^
-||targetsecure.kohler.com^
-||tt.ubs.com^
 !
 ! mboxedge31.tt.omtrdc.net disguised trackers
 !
-||experience.asb.co.nz^
-||metrics-target.siriusxm.com^
-||starget.intel.la^
-||starget.panerabread.com^
-||target.base.be^
-||target.chrysler.com^
-||target.footlocker.pt^
-||targetsecure.kohler.com^
-||tt.ubs.com^
 !
 ! mboxedge32-alb.tt.omtrdc.net disguised trackers
 !
 ||jptgtr.astellas.jp^
-||sats.spiegel.de^
-||starget.intel.cn^
-||starget.intel.co.jp^
-||starget.intel.co.kr^
-||starget.intel.com.tw^
-||target.aia.co.kr^
 !
 ! mboxedge32.tt.omtrdc.net disguised trackers
 !
-||jptgtr.astellas.jp^
-||sats.spiegel.de^
-||starget.intel.cn^
-||starget.intel.co.jp^
-||starget.intel.co.kr^
-||starget.intel.com.tw^
-||target.aia.co.kr^
 !
 ! mboxedge36-alb.tt.omtrdc.net disguised trackers
 !
-||assets2.gio.com.au^
-||experience.asb.co.nz^
-||sats.spiegel.de^
-||starget.intel.cn^
-||starget.intel.com.au^
-||starget.intel.com.tw^
 ||stt.keno.com.au^
-||stt.tab.com.au^
-||stt.thelott.com^
-||target.footlocker.de^
-||target.nrma.com.au^
-||target.premierinn.com^
-||target.synergy.net.au^
-||target.telenet.be^
-||targetsecure.kohler.com^
 !
 ! mboxedge36.tt.omtrdc.net disguised trackers
 !
-||assets2.gio.com.au^
-||experience.asb.co.nz^
-||sats.spiegel.de^
-||starget.intel.cn^
-||starget.intel.com.au^
-||starget.intel.com.tw^
-||stt.keno.com.au^
-||stt.tab.com.au^
-||stt.thelott.com^
-||target.footlocker.de^
-||target.nrma.com.au^
-||target.premierinn.com^
-||target.synergy.net.au^
-||target.telenet.be^
-||targetsecure.kohler.com^
 !
 ! creditsuisse.tt.omtrdc.net disguised trackers
 !
 !
 ! suncorpmetwayltd.tt.omtrdc.net disguised trackers
 !
-||assets2.gio.com.au^
-||assets2.suncorp.com.au^
 !
 ! duerzc3hf5let.cloudfront.net disguised trackers
 !
@@ -8397,10 +7533,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! deutschebankag.tt.omtrdc.net disguised trackers
 !
-||at.db-finanzberatung.de^
-||at.maxblue.de^
-||at.norisbank.de^
-||at.postbank.de^
 !
 ! mclarenautomotivelim.tt.omtrdc.net disguised trackers
 !
@@ -8442,15 +7574,12 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! demo3.tt.omtrdc.net disguised trackers
 !
-||demo3.management.testandtarget.omniture.com^
 !
 ! zooplus.tt.omtrdc.net disguised trackers
 !
-||dii3.zooplus.nl^
 !
 ! thermofisherscientif.tt.omtrdc.net disguised trackers
 !
-||dm-target.fishersci.com^
 !
 ! lifetech.tt.omtrdc.net disguised trackers
 !
@@ -8458,35 +7587,27 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! bcbsla.tt.omtrdc.net disguised trackers
 !
-||dxop.bcbsla.com^
 !
 ! asbbankltd.tt.omtrdc.net disguised trackers
 !
-||experience.asb.co.nz^
 !
 ! fullbeauty.tt.omtrdc.net disguised trackers
 !
-||experience.fbbrands.com^
 !
 ! astellas.tt.omtrdc.net disguised trackers
 !
-||jptgtr.astellas.jp^
 !
 ! wegmans.tt.omtrdc.net disguised trackers
 !
-||mbox.wegmans.com^
 !
 ! offermatica.tt.omtrdc.net disguised trackers
 !
-||mbox6.offermatica.com^
 !
 ! aaanortheast.tt.omtrdc.net disguised trackers
 !
-||mcdmetrics2.aaa.com^
 !
 ! siriusxmradio.tt.omtrdc.net disguised trackers
 !
-||metrics-target.siriusxm.com^
 !
 ! elb-geoblockemea-940286427.eu-west-1.elb.amazonaws.com disguised trackers
 !
@@ -8498,41 +7619,30 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! cooperativegroup.tt.omtrdc.net disguised trackers
 !
-||optimisation.coop.co.uk^
 !
 ! lloydsbankinggroup.tt.omtrdc.net disguised trackers
 !
 !
 ! fressnapftiernahrung.tt.omtrdc.net disguised trackers
 !
-||purpose.fressnapf.at^
-||purpose.fressnapf.de^
-||purpose.maxizoo.be^
-||purpose.maxizoo.fr^
-||purpose.maxizoo.pl^
 !
 ! fressnapftiernahrung-2.tt.omtrdc.net disguised trackers
 !
-||purpose.maxizoo.ie^
 !
 ! ezlinks.tt.omtrdc.net disguised trackers
 !
-||sabxt.teeoff.com^
 !
 ! zurcherkantonalbank.tt.omtrdc.net disguised trackers
 !
-||samt.zkb.ch^
 !
 ! csu.tt.omtrdc.net disguised trackers
 !
 !
 ! grafana.tt.omtrdc.net disguised trackers
 !
-||satgt.grafana.com^
 !
 ! spiegelverlagrudolfa.tt.omtrdc.net disguised trackers
 !
-||sats.spiegel.de^
 !
 ! apple.tt.omtrdc.net disguised trackers
 !
@@ -8542,7 +7652,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! penfed.tt.omtrdc.net disguised trackers
 !
-||sjourney.penfed.org^
 !
 ! sinkhole.paloaltonetworks.com disguised trackers
 !
@@ -8555,44 +7664,24 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! nbly.tt.omtrdc.net disguised trackers
 !
-||spersonalization.mrappliance.com^
-||spersonalization.neighborly.com^
-||spersonalization.rainbowintl.com^
 !
 ! aircanada.tt.omtrdc.net disguised trackers
 !
 !
 ! loyaltyone.tt.omtrdc.net disguised trackers
 !
-||starget.airmiles.ca^
 !
 ! stargetbitdefender.tt.omtrdc.net disguised trackers
 !
 !
 ! collegeboard.tt.omtrdc.net disguised trackers
 !
-||starget.collegeboard.org^
 !
 ! intelcorporation.tt.omtrdc.net disguised trackers
 !
-||starget.intel.cn^
-||starget.intel.co.jp^
-||starget.intel.co.kr^
-||starget.intel.com.au^
-||starget.intel.com.br^
-||starget.intel.com.tr^
-||starget.intel.com.tw^
-||starget.intel.de^
-||starget.intel.es^
-||starget.intel.fr^
-||starget.intel.it^
-||starget.intel.la^
-||starget.intel.pl^
-||starget.intel.ru^
 !
 ! lderbysa.tt.omtrdc.net disguised trackers
 !
-||starget.ladbrokes.be^
 !
 ! latrobe.tt.omtrdc.net disguised trackers
 !
@@ -8605,49 +7694,36 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! panera.tt.omtrdc.net disguised trackers
 !
-||starget.panerabread.com^
 !
 ! entertainmentbenefit.tt.omtrdc.net disguised trackers
 !
-||starget.plumbenefits.com^
-||starget.ticketsatwork.com^
-||starget.workingadvantage.com^
 !
 ! tv2danmark.tt.omtrdc.net disguised trackers
 !
-||starget.tv2.dk^
 !
 ! vodafonespain.tt.omtrdc.net disguised trackers
 !
-||starget.vodafone.es^
 !
 ! westjet.tt.omtrdc.net disguised trackers
 !
-||starget.westjet.com^
 !
 ! bbvaco.tt.omtrdc.net disguised trackers
 !
-||stmetrics.bbva.com.co^
 !
 ! bbvamx.tt.omtrdc.net disguised trackers
 !
-||stmetrics.bbva.mx^
 !
 ! bbvaperu.tt.omtrdc.net disguised trackers
 !
-||stmetrics.bbva.pe^
 !
 ! skydeutschlandag.tt.omtrdc.net disguised trackers
 !
-||stnt.sky.at^
-||stnt.sky.de^
 !
 ! mbfaustraliaptylimit.tt.omtrdc.net disguised trackers
 !
 !
 ! cpaaustralia.tt.omtrdc.net disguised trackers
 !
-||stt.cpaaustralia.com.au^
 !
 ! deakinuniversity.tt.omtrdc.net disguised trackers
 !
@@ -8657,7 +7733,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! tabcorpkeno.tt.omtrdc.net disguised trackers
 !
-||stt.keno.com.au^
 !
 ! nvidia.tt.omtrdc.net disguised trackers
 !
@@ -8667,22 +7742,15 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! tabcorpholdingslimit.tt.omtrdc.net disguised trackers
 !
-||stt.tab.com.au^
 !
 ! tattsgroup.tt.omtrdc.net disguised trackers
 !
-||stt.thelott.com^
 !
 ! onemarketingazd.tt.omtrdc.net disguised trackers
 !
-||sxp.allianz.de^
 !
 ! nordea.tt.omtrdc.net disguised trackers
 !
-||t.nordea.dk^
-||t.nordea.fi^
-||t.nordea.no^
-||t.nordea.se^
 !
 ! firstchoice.co.uk.insight.omtrdc.net disguised trackers
 !
@@ -8690,26 +7758,21 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! deka.tt.omtrdc.net disguised trackers
 !
-||target-omtrdc.deka.de^
 !
 ! samsungus.tt.omtrdc.net disguised trackers
 !
 !
 ! abanca.tt.omtrdc.net disguised trackers
 !
-||target.abanca.com^
 !
 ! accenture.tt.omtrdc.net disguised trackers
 !
 !
 ! aialife.tt.omtrdc.net disguised trackers
 !
-||target.aia.co.kr^
 !
 ! fcanafta.tt.omtrdc.net disguised trackers
 !
-||target.chrysler.com^
-||target.fiatusa.com^
 !
 ! onemarketingazeu.tt.omtrdc.net disguised trackers
 !
@@ -8717,8 +7780,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! onemarketingazeu-fpssl.tt.omtrdc.net disguised trackers
 !
-||target.allianz.ch^
-||target.elvia.ch^
 !
 ! ansysinc.tt.omtrdc.net disguised trackers
 !
@@ -8734,118 +7795,78 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! libertyglobalpaneu.tt.omtrdc.net disguised trackers
 !
-||target.base.be^
-||target.prd.base.be^
-||target.telenet.be^
 !
 ! bcbsnd.tt.omtrdc.net disguised trackers
 !
-||target.bcbsnd.com^
 !
 ! saintgobain.tt.omtrdc.net disguised trackers
 !
-||target.bd.dk^
 !
 ! intactfinancialcorpo.tt.omtrdc.net disguised trackers
 !
-||target.intact.ca^
-||target.intactinsurance.com^
 !
 ! cnamecustomer.tt.omtrdc.net disguised trackers
 !
 !
 ! fleetcortechnologies.tt.omtrdc.net disguised trackers
 !
-||target.bpbusinesssolutions.com^
-||target.fuelman.com^
 !
 ! lacaixa.tt.omtrdc.net disguised trackers
 !
-||target.caixabank.es^
 !
 ! champssports.tt.omtrdc.net disguised trackers
 !
-||target.champssports.ca^
 !
 ! footlocker.tt.omtrdc.net disguised trackers
 !
-||target.footlocker.at^
-||target.footlocker.be^
-||target.footlocker.ca^
-||target.footlocker.co.uk^
-||target.footlocker.cz^
-||target.footlocker.de^
-||target.footlocker.dk^
-||target.footlocker.es^
-||target.footlocker.fr^
-||target.footlocker.gr^
-||target.footlocker.hu^
-||target.footlocker.ie^
-||target.footlocker.it^
-||target.footlocker.lu^
-||target.footlocker.no^
-||target.footlocker.pl^
-||target.footlocker.pt^
-||target.footlocker.se^
 !
 ! changehealthcare.tt.omtrdc.net disguised trackers
 !
-||target.changehealthcare.com^
 !
 ! ciscosystemsinc.tt.omtrdc.net disguised trackers
 !
 !
 ! comenityservicing.tt.omtrdc.net disguised trackers
 !
-||target.comenity.net^
 !
 ! coxcommunications.tt.omtrdc.net disguised trackers
 !
 !
 ! cssversicherung.tt.omtrdc.net disguised trackers
 !
-||target.css.ch^
 !
 ! premierfarnell.tt.omtrdc.net disguised trackers
 !
-||target.newark.com^
 !
 ! eoncom.tt.omtrdc.net disguised trackers
 !
-||target.eon.de^
 !
 ! eycom.tt.omtrdc.net disguised trackers
 !
 !
 ! footlocker-2.tt.omtrdc.net disguised trackers
 !
-||target.footlocker.com.au^
 !
 ! groupama.tt.omtrdc.net disguised trackers
 !
-||target.groupama.fr^
 !
 ! healthengine.tt.omtrdc.net disguised trackers
 !
 !
 ! qvc.tt.omtrdc.net disguised trackers
 !
-||target.hsn.com^
 !
 ! hyundaimotorcompany.tt.omtrdc.net disguised trackers
 !
-||target.hyundaiusa.com^
 !
 ! mmsngaa.tt.omtrdc.net disguised trackers
 !
 !
 ! keybankassociation.tt.omtrdc.net disguised trackers
 !
-||target.key.com^
 !
 ! michaelsstores.tt.omtrdc.net disguised trackers
 !
-||target.michaels.com^
 !
 ! microsoftmscompoc.tt.omtrdc.net disguised trackers
 !
@@ -8861,64 +7882,48 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! insuranceaustraliali.tt.omtrdc.net disguised trackers
 !
-||target.nrma.com.au^
 !
 ! freescalesemiconduct.tt.omtrdc.net disguised trackers
 !
-||target.nxp.com^
 !
 ! pandasecurity.tt.omtrdc.net disguised trackers
 !
 !
 ! whitbreadgroup.tt.omtrdc.net disguised trackers
 !
-||target.premierinn.com^
 !
 ! sapientinc.tt.omtrdc.net disguised trackers
 !
-||target.publicissapient.com^
 !
 ! questdiagnostics.tt.omtrdc.net disguised trackers
 !
-||target.questdiagnostics.com^
 !
 ! southernwine.tt.omtrdc.net disguised trackers
 !
-||target.sgproof.com^
 !
 ! sivasdescalzo.tt.omtrdc.net disguised trackers
 !
-||target.sivasdescalzo.com^
 !
 ! sportsmanguide.tt.omtrdc.net disguised trackers
 !
-||target.sportsmansguide.com^
 !
 ! stanfordchildrens.tt.omtrdc.net disguised trackers
 !
-||target.stanfordchildrens.org^
 !
 ! sunlifeassurance.tt.omtrdc.net disguised trackers
 !
-||target.sunlife.co.id^
-||target.sunlife.com.hk^
-||target.sunlife.com.ph^
 !
 ! sunlifeassurance-2.tt.omtrdc.net disguised trackers
 !
-||target.sunlife.com^
-||target.sunlifeglobalinvestments.com^
 !
 ! swinburne.tt.omtrdc.net disguised trackers
 !
 !
 ! synergy.tt.omtrdc.net disguised trackers
 !
-||target.synergy.net.au^
 !
 ! thetruthinitiativefo.tt.omtrdc.net disguised trackers
 !
-||target.thetruth.com^
 !
 ! troweprice.tt.omtrdc.net disguised trackers
 !
@@ -8932,32 +7937,23 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! volkswagenfinancials.tt.omtrdc.net disguised trackers
 !
-||target.vwfs.cz^
-||target.vwfs.de^
-||target.vwfs.es^
-||target.vwfs.fr^
 ||target.vwfs.gr^
 ||target.vwfs.it^
-||target.vwfs.mx^
 !
 ! volkswagenfinancials-2.tt.omtrdc.net disguised trackers
 !
-||target.vwfs.ie^
 !
 ! walgreenco.tt.omtrdc.net disguised trackers
 !
 !
 ! carlzeiss.tt.omtrdc.net disguised trackers
 !
-||target.zeiss.de^
 !
 ! adobeinternalmobiles.tt.omtrdc.net disguised trackers
 !
-||targetlr.adobe.com^
 !
 ! kohlerco.tt.omtrdc.net disguised trackers
 !
-||targetsecure.kohler.com^
 !
 ! ibm.tt.omtrdc.net disguised trackers
 !
@@ -8970,20 +7966,15 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! rbs-fpssl.tt.omtrdc.net disguised trackers
 !
-||tt.ulsterbank.co.uk^
-||tt.ulsterbank.ie^
 !
 ! sjab.tt.omtrdc.net disguised trackers
 !
-||tt.sj.se^
 !
 ! ubsag.tt.omtrdc.net disguised trackers
 !
-||tt.ubs.com^
 !
 ! eastwestbank.tt.omtrdc.net disguised trackers
 !
-||ttarget.eastwestbank.com^
 !
 ! faz.tt.omtrdc.net disguised trackers
 !
@@ -8993,21 +7984,12 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! logitech.tt.omtrdc.net disguised trackers
 !
-||webtarget.astrogaming.com^
-||webtarget.logicool.co.jp^
-||webtarget.logitech.com^
-||webtarget.logitech.com.cn^
-||webtarget.logitechg.com^
-||webtarget.logitechg.com.cn^
 !
 ! ingbelgium.tt.omtrdc.net disguised trackers
 !
-||www4s.ing.be^
 !
 ! hukcoburg.tt.omtrdc.net disguised trackers
 !
-||xps.huk.de^
-||xps.huk24.de^
 !
 ! AdSpyglass : 0i0i0i0.com disguised advertising networks
 ! included to BaseFilter/sections/cname_adservers.txt
@@ -9528,7 +8510,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||tzovkp.aboutyou.at^
 ||ualkzq.moobel1.ee^
 ||uasmdd.icaniwill.no^
-||udgrbq.malwarebytes.com^
 ||ueuqui.esprit.nl^
 ||uflfhl.mercci22.com^
 ||ufsmcn.blackspade.com.tr^
@@ -9784,7 +8765,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 !
 !
-||aajmmd.aireuropa.com^
 ||aarqmo.culturekings.co.nz^
 ||afecvu.bulevip.com^
 ||ahsmpt.cheerz.com^
@@ -9799,12 +8779,8 @@ charlestownwyllie.oaklawnnonantum.com^
 ||cueohf.nuevopeugeot3008.com^
 ||cvaxjw.mynuface.com^
 ||czujjs.crownandcaliber.com^
-||dbmyvl.apartmentfinder.com^
-||ddmfrg.modivo.bg^
-||denpjz.jamesedition.com^
 ||dhkyrl.discountmags.com^
 ||doaysw.novusbio.com^
-||dptgdj.usagi-online.com^
 ||dpycax.gallerycollection.com^
 ||dxpxfn.autobandenmarkt.nl^
 ||dxrlkh.icanvas.com^
@@ -9813,9 +8789,7 @@ charlestownwyllie.oaklawnnonantum.com^
 ||ebeudf.tabirai.net^
 ||edeqqd.helbrecht.com^
 ||eftken.finn-flare.ru^
-||ejbbcf.finishline.com^
 ||ejimtl.costway.com^
-||ejrbgi.tous.com^
 ||emrdnt.sumaity.com^
 ||ensbrs.myron.com^
 ||eoiaso.onofre.com.br^
@@ -9827,8 +8801,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||iqbjqv.airarabia.com^
 ||janzoz.1001pneus.fr^
 ||jdgtgb.dnn.de^
-||jdgtgb.haz.de^
-||jdgtgb.ln-online.de^
 ||jdgtgb.lvz.de^
 ||jdgtgb.volksstimme.de^
 ||jktqvc.vamsvet.ru^
@@ -9844,7 +8816,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||jzqfac.bestsecret.ch^
 ||jzzdsu.piscineshop.com^
 ||kebtul.lamp24.se^
-||kftfhp.furusato-tax.jp^
 ||ngyxtr.ripcurl.com^
 ||nhdevm.meinenamenskette.com^
 ||nlfhlc.careofcarl.com^
@@ -9855,23 +8826,19 @@ charlestownwyllie.oaklawnnonantum.com^
 ||sszadd.artdeco.de^
 ||tdbnom.madeleine.de^
 ||tixteo.glamcor.com^
-||xrchmz.mobafire.com^
 ||xugxwq.e-hoi.de^
 ||xvwvdt.dehe.pl^
 ||ypwzcq.tink.de^
 ||ypzktj.fly.pl^
 ||yqorwz.weisshaus.at^
 ||yqymyr.favori.com.tr^
-||yrgncw.footlocker.de^
 ||ysaaks.mobiauto.com.br^
 ||ysekcv.voyage-prive.co.uk^
 !
 !
 ||btkbei.courir.com^
-||bzuvlx.e-file.com^
 ||criteo.gap.ae^
 ||cueohf.forumotion.com^
-||cvhefd.ixbt.com^
 ||ddncow.impo.com^
 ||efbenj.adorebeauty.com.au^
 ||efuxqe.tatilbudur.com^
@@ -9880,10 +8847,8 @@ charlestownwyllie.oaklawnnonantum.com^
 ||fgfecw.rebelle.com^
 ||fibqxe.lagrandeepicerie.com^
 ||fksngj.bonnyread.com.tw^
-||fqppgv.cheapoair.com^
 ||fvnnxo.cuckooland.com^
 ||fwejqe.gundrymd.com^
-||fxmkij.jny.com^
 ||gdumfy.home-design.schmidt^
 ||getpxq.rivolishop.com^
 ||gforat.grahambrown.com^
@@ -9893,12 +8858,9 @@ charlestownwyllie.oaklawnnonantum.com^
 ||ggsnoq.cavalierebici.it^
 ||ghhubu.gear4music.fi^
 ||ghonnz.columbiasports.co.jp^
-||ghrzlu.skechers.com.tr^
-||gjmovc.epapoutsia.gr^
 ||gkcqyo.aquazzura.com^
 ||gkrsdn.cuoieriashop.com^
 ||gmxtkh.morris4x4center.com^
-||gnreyt.toom.de^
 ||gogaej.momastore.jp^
 ||gpuijq.mothercare.com.sa^
 ||gspqch.cake.jp^
@@ -9913,29 +8875,21 @@ charlestownwyllie.oaklawnnonantum.com^
 ||hjhgth.sklepbaterie.pl^
 ||hkskqs.belvilla.fr^
 ||hlahal.bellissima.com^
-||hlygsp.modivo.ro^
 ||hmeagu.e87.com^
 ||hmsagy.uniecampus.it^
 ||hoqlah.rajapack.de^
 ||hphpfl.spyoptic.com^
-||hqwtqa.intelligence-artificielle-school.com^
 ||hrwgsq.loesdau.de^
 ||hsaxca.americatv.com.pe^
 ||huccia.lozkoholicy.pl^
-||hvrhgt.thescottishsun.co.uk^
-||hvrhgt.thesun.ie^
 ||hvxymx.tui.pl^
 ||hwknsd.shoepassion.de^
 ||hwwjsi.aboutyou.pl^
 ||hxiabp.colins.com.tr^
-||hyybul.kaskus.co.id^
-||hzhsas.kriso.ee^
 ||hztrhd.guardianangeldevices.com^
 ||hzymxd.nocibe.fr^
 ||idlqzb.puntoscolombia.com^
-||iethpk.notino.ro^
 ||ifmonx.commercialrealestate.com.au^
-||ifqtfo.rugsusa.com^
 ||iremmk.estnation.co.jp^
 ||ivbxao.roastmarket.de^
 ||ivqfxl.brogle.de^
@@ -9943,17 +8897,13 @@ charlestownwyllie.oaklawnnonantum.com^
 ||jfyecc.machineseeker.com^
 ||jggskx.eteweb-shop.com^
 ||jqsrmm.sousou.co.jp^
-||jxiwdw.ufret.jp^
 ||kbviuj.enoteca.co.jp^
-||kgqxzw.blue-tomato.com^
 ||khfiwx.sephora.com.br^
 ||khmyte.mobstub.com^
 ||kirhtq.anicom-sompo.co.jp^
 ||lenpmh.francoisesaget.com^
 ||nnkkxb.nuts.com^
 ||nuforc.justjeans.co.nz^
-||nxovay.fo-online.jp^
-||nzzvvf.goldengoose.com^
 ||oawzql.pursuefitness.co.uk^
 ||obdqbi.brooksbrothers.co.jp^
 ||ocmxbu.hanatour.com^
@@ -9965,17 +8915,12 @@ charlestownwyllie.oaklawnnonantum.com^
 ||rflbhv.3ple.jp^
 ||rfmfrg.yamap.com^
 ||wpyvue.idealwine.com^
-||wzoxvb.sneakerstudio.com.ua^
-||xbwpfs.fotocasa.es^
 ||xqshsw.freskincare.com^
 ||xunzbx.mon-abri-de-jardin.com^
 ||xuqujk.raven.nl^
-||xutolr.mantan-web.jp^
 ||xvmmdd.golfavenue.ca^
 ||ynwqna.mayblue.co.kr^
 ||zdcjts.asics.com^
-||zgumwv.stepstone.de^
-||zitcrd.aimerfeel.jp^
 !
 !
 !
@@ -10266,7 +9211,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||sst.nab.com.au^
 ||suncorp.activate.ensighten.com^
 ||t.janieandjack.com^
-||tagman.britishairways.com^
 ||tagman.crystalsummer.co.uk^
 ||tagman.fotolia.com^
 ||tagman.intercall.com^
@@ -10288,7 +9232,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||tags.wyndhamhotels.com^
 ||tam.volkswagen.com^
 ||tdi.cartoonnetwork.com^
-||tm.hdmtools.com^
 ||tms-test.nab.com.au^
 ||tms.americanexpress.com^
 ||tms.capitalone.com^
@@ -10572,13 +9515,11 @@ charlestownwyllie.oaklawnnonantum.com^
 ||1ywk8ynty.benediktkick.com^
 ||7wrxo2xh.iriscreative.co^
 ||aardvark.helpingpets.org.uk^
-||aardvark.mission-austria.at^
 ||aardvark.revolana.rs^
 ||aardvark.steadybit.com^
 ||aardvark.tonicaudio.com^
 ||aardwolf.benbrignell.com^
 ||aardwolf.chrisblackwell.me^
-||aardwolf.keygen.sh^
 ||aj8md.johnhenry.ie^
 ||albatross.creacoon.com^
 ||albatross.mypromo.co^
@@ -10586,17 +9527,14 @@ charlestownwyllie.oaklawnnonantum.com^
 ||alligator.remotecyberwork.com^
 ||alpaca.miidbaby.com^
 ||alpaca.reclaimthenet.org^
-||alpaca.thesocialmedwork.com^
 ||alpaca.wingmantracker.com^
 ||am2lma0ay.xrpmerchstore.com^
 ||amphibian.juergenhaller.at^
 ||amphibian.pinestc.com^
 ||amphibian.studionimbus.nl^
 ||angelfish.grayscale.design^
-||angelfish.owlbear.rodeo^
 ||anglerfish.pfolios.net^
 ||anglerfish.tinydeskapp.com^
-||ant.prefinery.com^
 ||anteater.audioadventuregame.com^
 ||anteater.benborgers.com^
 ||anteater.slyvon.com^
@@ -10610,14 +9548,12 @@ charlestownwyllie.oaklawnnonantum.com^
 ||antelope.u3a.com.au^
 ||antlion.codivores.com^
 ||antlion.hendrikhaack.de^
-||ape.mfj.se^
 ||ape.nusii.com^
 ||ape.pytch.co.uk^
 ||ape.smartplanschema.se^
 ||aphid.thyself.me^
 ||armadillo.axeneo7.qc.ca^
 ||armadillo.caj.ms^
-||armadillo.gothiacup.se^
 ||armadillo.stacking.club^
 ||asp.ashesashes.org^
 ||asp.chop-shop.com.au^
@@ -10629,13 +9565,11 @@ charlestownwyllie.oaklawnnonantum.com^
 ||badger.pager.app^
 ||baldeagle.e-ma.re^
 ||baldeagle.eternalmma.com^
-||bandicoot.mohit.dev^
 ||barracuda.ottsysteme.rs^
 ||basilisk.community-arts.net^
 ||basilisk.laosima.com^
 ||bass.alfrednerstu.com^
 ||bass.kathryncallaghan.co.uk^
-||bass.kidneystonediet.com^
 ||bass.slugnews.com^
 ||bass.taivo.ai^
 ||bat.heelix.be^
@@ -10662,7 +9596,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||blackbird.everythinginmoderation.co^
 ||blackbird.marcelgil.com^
 ||blackbird.stickerclub.org^
-||bluejay.postmediagroup.com^
 ||bluejay.wearegray.com^
 ||boa.karenwhooley.com^
 ||boa.nolongerset.com^
@@ -10675,7 +9608,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||bobcat.snapshooter.io^
 ||bobolink.itpeters.com^
 ||booby.deanyeong.com^
-||boom.laravel.io^
 ||bovid.arshaw.com^
 ||bovid.docutize.de^
 ||bovid.neural.love^
@@ -10695,7 +9627,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||cardinal.businessfirstonline.co.uk^
 ||cardinal.ensembleblock.com^
 ||cardinal.iwgb.org.uk^
-||caribou.color.io^
 ||caribou.mcgregorpublishing.com^
 ||carp.pbncontent.com^
 ||carp.seniorsinjobs.com^
@@ -10703,10 +9634,8 @@ charlestownwyllie.oaklawnnonantum.com^
 ||cat.beunitedinchrist.com^
 ||cat.doebankdesigns.com^
 ||cat.gfx.io^
-||cat.laravel-news.com^
 ||cat.lasalturasresort.com^
 ||cat.thisminute.app^
-||cat.ticketshifu.com^
 ||cat.tinylittlebusinesses.com^
 ||cat.weddingsabroad.com^
 ||caterpilla.ibon.live^
@@ -10717,7 +9646,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||cattle.ajyd.org.au^
 ||cattle.apisyouwonthate.com^
 ||cattle.domaincomet.com^
-||cattle.eprc.tools^
 ||cattle.kirkebaekke.dk^
 ||cattle.mes-renovateurs.com^
 ||cattle.spiral11.com^
@@ -10732,140 +9660,74 @@ charlestownwyllie.oaklawnnonantum.com^
 ||cephalopod.staff.design^
 ||chameleon.rndm.uk^
 ||cheetah.gaptry.com^
-||cheetah.songrender.com^
 ||cheetah.zeh.co.il^
 ||chickadee.hispanicinjobs.com^
 ||chickadee.mikebifulco.com^
-||chicken.alpla.info^
 ||chicken.clerklabs.com^
-||chicken.couleur.io^
 ||chicken.tjsoler.dev^
 ||chicken.zwei.haus^
-||chimpanzee.designerdailyreport.com^
 ||chimpanzee.ines-papert.com^
 ||chinchilla.68keys.io^
-||chinchilla.christinefontaine.com^
-||chinchilla.twayapp.com^
-||chinchilla.ubclaunchpad.com^
-||chipmunk.brandy.is^
-||chipmunk.pixelko.de^
-||clam.figmachina.com^
 ||clam.mglaman.dev^
-||clownfish.onvard.de^
 ||clownfish.philipkiely.com^
-||clownfish.wrestlingiq.com^
-||clownfish.yrgo.se^
-||cobra.michaelkoper.com^
 ||cockroach.shellstartupengine.live^
 ||cod.dm.link^
 ||cod.fotis.xyz^
 ||cod.onemanandhisblog.com^
 ||cod.serverlesslaravelcourse.com^
-||cod.tandartspraktijkjagtkade.nl^
-||condor.oskarthoren.com^
 ||condor.stadttunnel-feldkirch.at^
 ||coral.bladestudy.net^
 ||coral.defygravity.co^
-||cougar.arenahq.io^
-||cougar.wzulfikar.com^
-||coyote.12gem.me^
-||coyote.alboweb.nl^
-||coyote.gnx.cloud^
-||coyote.hopr.swiss^
 ||coyote.nickgurney.com^
-||coyote.titlerun.xyz^
-||coyote.txet.ch^
 ||crab.dunkeldbutchers.co.uk^
 ||crab.goalcanvas.com^
 ||crane.maggsgroup.com^
-||crane.thegardenroomguide.co.uk^
 ||crane.trescolori.cloud^
 ||crawdad.craiga.id.au^
 ||crawdad.dillonerhardt.com^
-||crayfish.fansubbing.com^
 ||crayfish.miamilo.com^
 ||crocodile.brightonruby.com^
 ||cuckoo.clientrock.app^
 ||cuckoo.jerandky.com^
-||cuckoo.minaexplorer.com^
 ||cuckoo.peoplefirstjobs.com^
 ||cxzp.pjrvs.com^
 ||dakqbwpduu.coywolf.io^
-||damselfly.clk.click^
-||damselfly.creativeclick.com.au^
-||damselfly.jakekorth.com^
-||damselfly.previously.today^
 ||deer.m1x.co^
-||deer.ray.io^
 ||dingo.harmanly.com^
 ||dingo.moehring.dev^
 ||dog.christinamoore.us^
 ||dog.diversityinjobs.com^
 ||dog.franchisesocial.co.uk^
 ||dog.ghvenue.com^
-||dog.justsketch.me^
 ||dog.orbit.love^
-||dog.rejuvenateyouohio.com^
-||dolphin.biodom.rs^
 ||dolphin.maybe.co^
-||dolphin.sfelc.com^
-||donkey.aerzteteam-luppe.de^
-||donkey.annieswinecottagepowell.com^
-||donkey.bahr.dev^
-||donkey.briangershon.com^
-||donkey.elegantmusicgroup.com^
 ||donkey.guggenbichler.co.at^
-||donkey.hackoregon.org^
-||donkey.masteringfinland.com^
-||donkey.routinehub.co^
-||donkey.thedowhatyoulovepodcast.com^
-||dormouse.consentkit.com^
-||dormouse.morningchorusrecords.com^
-||dove.fullcalendar.io^
 ||dragon.codemakes.art^
 ||dragon.sh2.com^
-||dragonfly.codebar.ch^
 ||dragonfly.filmmakerfreedom.com^
-||dragonfly.jala-one.com^
 ||eagle.joulescope.com^
 ||earthworm.lidi.today^
-||earthworm.makethemdebate.com^
 ||earthworm.ohmydeck.com^
 ||echidna.eyalgantz.me^
 ||echidna.honeybadger.io^
-||eel.beekeeperstudio.io^
-||egret.brothers.studio^
 ||egret.hispanicjobexchange.com^
 ||egret.refreshed.domains^
-||elephant.clerk.ai^
-||elephant.stempelwiese.de^
-||elephant.superdense.com^
-||elk.andrewfomera.com^
-||elk.itiden.se^
 ||elk.okcrowd.co^
-||elk.techphotoguy.com^
 ||emu.andenglish.co^
-||emu.cortexfutura.com^
-||emu.pin13.net^
 ||falcon.backgroundnoise.app^
 ||falcon.rowanmanning.com^
-||fancyrat.calebporzio.com^
-||fancyrat.flatuicolors.com^
 ||fancyrat.keurslager-goeminne.be^
 ||fancyrat.spacestation.news^
 ||felidae.mmm.page^
 ||felidae.theforeignarchitect.com^
 ||ferret.ecvan.io^
 ||ferret.helpspace.com^
-||ferret.linksoftwarellc.com^
 ||ferret.siloam.ch^
 ||finch.market.xyz^
 ||firefly.daroncreative.co^
 ||firefly.maier.tech^
 ||fish.canyouexplain.me^
 ||fish.eventpay.be^
-||fish.muted.io^
-||fish.whitney.org^
 ||flamingo.abihome.de^
 ||flamingo.stacking-club.com^
 ||flea.artisan.school^
@@ -10885,20 +9747,15 @@ charlestownwyllie.oaklawnnonantum.com^
 ||gecko.lpkr.net^
 ||gecko.rrrelax.app^
 ||gecko.withclarify.com^
-||gerbil.buf.build^
-||gibbon.ehubhealth.com^
 ||giraffe.bkmhorten.no^
 ||giraffe.talktalent.com^
 ||giraffe.viatorci.com^
 ||goat.aicontentdojo.com^
-||goat.codeofar.ms^
 ||goat.studiobruikbaar.nl^
 ||goat.vrds.app^
 ||goldfish.boleary.dev^
 ||goldfish.mergeedu.com^
-||goldfish.shingle.fi^
 ||goose.markerchase.com^
-||goose.pooltogether.com^
 ||gopher.mina.ca^
 ||gorilla.celcyon.com^
 ||gorilla.hakai.org^
@@ -10907,17 +9764,13 @@ charlestownwyllie.oaklawnnonantum.com^
 ||grouse.i21.co^
 ||grouse.textile.io^
 ||grouse.ultimateballistics.com^
-||guan.domainnamesanity.com^
 ||guan.elfenkueche.at^
 ||guanaco.jden.me^
-||guanaco.redpixelthemes.com^
 ||guineapig.espressive.com^
-||guineapig.recap.io^
 ||guineapig.themenaffin.de^
 ||gull.mayansmithgobat.com^
 ||guppy.ausowned.com.au^
 ||guppy.ironmic.fm^
-||haddock.affilimate.com^
 ||haddock.jeffreyknox.dev^
 ||haddock.simgenie.app^
 ||haddock.stillio.com^
@@ -10926,13 +9779,10 @@ charlestownwyllie.oaklawnnonantum.com^
 ||hamster.darstellendekuenste.de^
 ||hare.felix-schmid.de^
 ||hawk.affio.co.uk^
-||hawk.makroskop.eu^
 ||hawk.mjsarfatti.com^
-||hedgehog.fightforthefuture.org^
 ||hedgehog.impira.com^
 ||heron.joel.is^
 ||heron.morphiq.digital^
-||heron.notability.com^
 ||heron.oneaudiobooks.app^
 ||heron.scarletnoir.co^
 ||herring.panda.network^
@@ -10948,12 +9798,7 @@ charlestownwyllie.oaklawnnonantum.com^
 ||horse.uhaveto.click^
 ||horse.usemiso.com^
 ||horse.vesuvius-publishing.com^
-||horse.zwei-bags.com^
-||hoverfly.cdengine.co.uk^
-||hoverfly.dailyblocks.tv^
-||hoverfly.papercrowns.com^
 ||hyena.baseline.is^
-||hyena.kitafund.com^
 ||hyena.wearegray.co^
 ||i5ixiwch2f.themakersmob.com^
 ||iguana.delbaoliveira.com^
@@ -10977,7 +9822,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||kite.oakes.software^
 ||kite.ofenbau-voppichler.at^
 ||kiwi.emilkowal.ski^
-||kiwi.railway.app^
 ||koala.moontells.com^
 ||koala.mynestbox.co.uk^
 ||koala.quantumfirelabs.com^
@@ -10987,51 +9831,37 @@ charlestownwyllie.oaklawnnonantum.com^
 ||koi.lkae.dev^
 ||koi.omnimove.health^
 ||koi.valleywestlandscapes.com^
-||ks42zt.spec.fm^
 ||ladybug.cargolabs.com^
 ||ladybug.dfour.space^
 ||ladybug.ethanprintz.com^
 ||ladybug.paulstovell.com^
-||landfowl.typegang.com^
 ||landsnail.bindle.io^
 ||landsnail.brownfield.dev^
 ||landsnail.garasjeport1.no^
 ||lark.frugalweb.xyz^
 ||leech.fuchsegg.at^
-||leech.privacycloud.com^
-||leech.stargate-project.de^
 ||lemming.nicolasmenard.com^
 ||lemming.vivian.do^
 ||leopard.ui-snippets.dev^
 ||leopard.understandit.se^
-||leopon.luckycasts.com^
-||leopon.originalmineral.com^
 ||limpet.coinponent.com^
 ||limpet.eddiehinkle.com^
 ||limpet.yago.dev^
 ||lion.lastfrontiermagazine.com^
 ||llama.eniston.io^
-||llama.growthinkers.nl^
-||llama.mallardbay.com^
-||llama.moodgym.com.au^
 ||lobster.justunderwear.com^
 ||lobster.tonebleed.com^
 ||locust.ausrebellion.earth^
 ||loon.africanamericanjobsearch.com^
 ||loon.analogjoe.com^
 ||loon.ohmyfunds.com^
-||louse.messengo.com^
 ||louse.seanconnolly.dev^
-||louse.sigle.io^
 ||lungfish.datadividendproject.com^
 ||lynx.bitefullbox.com^
 ||lynx.simpleparish.com^
-||manatee.creativepassport.net^
 ||marlin.firstline.org^
 ||marmoset.easycolour.app^
-||marmot.hippiemodernism.com^
 ||marmot.ivymayhem.io^
-||marmot.theshootingcentre.com^
 ||marsupial.dbcontractingltd.ca^
 ||marten.countertype.com^
 ||marten.emperor-creative.com^
@@ -11042,20 +9872,15 @@ charlestownwyllie.oaklawnnonantum.com^
 ||meadowlark.psynapse.no^
 ||meadowlark.tempus.im^
 ||meerkat.bigcrazylife.com^
-||mink.faq-bregenzerwald.com^
 ||minnow.clintwinter.me^
 ||minnow.mimosaagency.com^
 ||mite.cotinga.io^
 ||mite.tetrameros.com^
 ||mockingbir.sgfunited.com^
-||mole.energizer.eu^
-||mollusk.saferingz.com^
 ||mollusk.working.actor^
 ||mongoose.thechocolatelife.com^
 ||monkey.colinjohnston.com^
-||moth.artsmia.org^
 ||moth.treeferral.com^
-||mule.caddyserver.com^
 ||newt.javier.dev^
 ||nf1nknlw.mateforevents.com^
 ||ocelot.anthroquiches.fr^
@@ -11063,7 +9888,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||octopus.couragetrainingcentre.com^
 ||opossum.roleup.com^
 ||orangutan.equaliteam.com^
-||orangutan.renovare.org^
 ||orangutan.va4indieauthors.com^
 ||orca.getnodo.com^
 ||orca.weatherontheway.app^
@@ -11071,70 +9895,50 @@ charlestownwyllie.oaklawnnonantum.com^
 ||ostrich.laurierepko.com^
 ||ostrich.pergaudiaadastra.de^
 ||otter.goetheanum.media^
-||otter.johnfoster.com^
 ||otter.preferredequineonline.com^
-||owl.heidipay.com^
 ||owl.sentrydiscord.dev^
 ||ox.first-law.com^
-||pa5xjc.m1guelpf.me^
-||panda.moritz-petersen.de^
 ||panda.mvhphotoproject.org^
 ||panda.teraskolmio.fi^
 ||panther.activelink.ie^
-||panther.atgonlinecoaching.com^
-||panther.datocms.com^
 ||panther.dividesignservice.com^
 ||panther.essentialwellnessyoga.com.au^
 ||panther.hoprnet.org^
-||panther.thestocks.im^
 ||panther.tigil.rs^
 ||parrotfish.wilderworld.com^
 ||peacock.davidlevai.com^
 ||peacock.tourismtuneup.com^
 ||perch.luckydiff.com^
-||perch.searchwp.com^
 ||pheasant.swinlead.com^
 ||pigeon.thankyuu.com^
 ||pinniped.gardenofficeguide.co.uk^
 ||pinniped.oslocrisislinetech.com^
-||piranha.jsmobiledev.com^
 ||planarian.reverberate.org^
 ||platypus.colly.com^
 ||platypus.facet.net^
 ||polarbear.codeday.org^
 ||pony.ftm.cat^
-||porcupine.dvresolve.com^
 ||porcupine.srhdesign.co.uk^
-||porpoise.fruittreecottage.com.au^
-||prawn.fffuel.co^
 ||ptarmigan.anthonyledonne.com^
 ||ptarmigan.q-free.com^
-||puffin.geocode.earth^
-||python.mux.com^
 ||quail.efix.uk^
 ||rabbit.radicalxchange.org^
 ||rabbit.upwardhomes.net^
 ||raccoon.donateflow.com^
 ||roadrunner.ausmv.com.au^
-||rodent.beersport.com^
 ||rook.deutz-fahramerica.com^
-||rook.moodgym.de^
 ||roundworm.womeninjobs.com^
-||sailfish.kentcdodds.com^
 ||sailfish.mastercw.com^
 ||salamander.laboucheriebio.com^
 ||salamander.showandtelldata.com^
-||salmon.thespiritualpsychologist.co.uk^
 ||sawfish.johnbraun.blog^
 ||sawfish.loqbooq.app^
-||scallop.esolia.pro^
 ||scallop.productionrails.com^
 ||scallop.vav.link^
 ||scorpion.indexforwp.com^
 ||scorpion.smskmail.com^
 ||seahorse.dexterityvisuals.com^
 ||seahorse.okse.no^
-||silkworm.energizergrouplegal.com^
 ||silkworm.westwoodmbc.org^
 ||silverfish.trustduty.com^
 ||skink.asorman.io^
@@ -11143,21 +9947,15 @@ charlestownwyllie.oaklawnnonantum.com^
 ||smelt.allenpike.com^
 ||snipe.mizzuu.co^
 ||sole.maraispatrimoine.com^
-||sole.pretto.fr^
 ||sparrow.collabwithpedal.com^
-||sparrow.uitvaartzorg-vanraemdonck.be^
 ||sparrow.workingincontent.com^
 ||spider.scottw.com^
 ||spoonbill.deknot.io^
-||spoonbill.memberkit.com.br^
 ||squid.adart.cc^
 ||squid.antevo.com.au^
 ||squid.dylancastillo.co^
-||squirrel.laravel-mix.com^
 ||starman.usefathom.com^
 ||stingray.codecoolture.com^
-||stingray.reform.app^
-||stoat.death-to-ie11.com^
 ||stork.ibite.company^
 ||swallow.axiom.co^
 ||swan.visualma.com^
@@ -11165,60 +9963,41 @@ charlestownwyllie.oaklawnnonantum.com^
 ||swift.jos.ht^
 ||swift.unovy.net^
 ||swordfish.holzschuhe.at^
-||swordfish.hotcross.com^
-||swordtail.thocstock.com^
 ||tahr.componentsui.com^
 ||tahr.rasen.dev^
 ||takin.cors.digital^
 ||takin.revolana.fr^
-||tarantula.hashicorp.com^
 ||tick.pcrpriser.se^
 ||tiger.aofinance.com.au^
-||tigershark.moonpot.com^
 ||tigershark.oilpriceapi.com^
 ||tigershark.vandevliet.me^
-||tiglon.beyondco.de^
 ||tiglon.davidroessli.com^
-||tiglon.orisdental.no^
 ||toad.frontendmentor.io^
-||tortoise.mdx.one^
-||tortoise.transistor.fm^
 ||treefrog.kaffeknappen.no^
 ||treefrog.mii-chi.app^
 ||treefrog.tschmeisser.com^
 ||treefrog.walkingwithdaddy.com^
 ||trout.stocketa.com^
-||trout.travelmassive.com^
-||turkey.tella.tv^
 ||turtle.geshem.space^
-||uktgg.dev-tester.com^
 ||vampirebat.datingmedellin.com^
 ||vampirebat.git-tower.com^
 ||vampirebat.sharpend.io^
 ||vicuna.callisoma.com^
 ||vicuna.casa-moebel.at^
-||vole.contemporaryartlibrary.org^
 ||vole.leonhitchens.com^
-||vole.noteapps.info^
 ||vulture.downzeroky.com^
 ||wallaby.cron.help^
 ||wallaby.legendkeeper.com^
 ||wallaby.short1.link^
-||warbler.nycmode.com^
 ||warbler.resumebuilder.dev^
 ||waterboa.midu.dev^
-||weasel.accomplice.ai^
 ||whitefish.finanzritter.com^
 ||whitefish.johnsandtaylor.com^
-||wildcat.fspy.io^
 ||wildfowl.minter.io^
 ||wolf.idthompson.com^
 ||wolf.minecraftserverhosts.com^
 ||wombat.tigil.fr^
-||woodpecker.eatfresh.tech^
 ||woodpecker.seabits.com^
-||worm.paulstamatiou.com^
-||yak.embeddedartistry.com^
 !
 ! eu.usefathom.com disguised trackers
 !
@@ -11237,24 +10016,17 @@ charlestownwyllie.oaklawnnonantum.com^
 ! Company name: GMO Internet Group
 !
 !
-||d.newssuite.sony.net^
-||i.newssuite.sony.net^
-||j.newssuite.sony.net^
 !
 !
-||d.newssuite.sony.net^
 !
 !
 ||video.sp.gmossp-sp.jp^
 !
 !
-||i.newssuite.sony.net^
-||j.newssuite.sony.net^
 !
 !
 !
 !
-||manage.newssuite.sony.net^
 !
 !
 !
@@ -13138,7 +11910,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||app.info.aviationweek.com^
 ||app.info.avid.com^
 ||app.info.fidelity.com^
-||app.info.fishersci.com^
 ||app.info.jdpa.com^
 ||app.info.markit.com^
 ||app.info.polycom.com^
@@ -13197,7 +11968,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||app.tableausoftware.com^
 ||app.uk.partner.equifax.com^
 ||app.update.vodafone.co.uk^
-||app.www-102.aig.com^
 ||app.your.level3.com^
 ||app.zmail.zionsbank.com^
 ||application.rasmussen.edu^
@@ -13352,7 +12122,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||www.hasslefree.redwingshoes.com^
 ||www.resources.att.com^
 ||www.save.adp.ca^
-||www.videos.adp.ca^
 !
 !
 ||a.mx.information.maileva.com^
@@ -13378,7 +12147,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||tracking.stihl.lu^
 ||tracking.stihl.nl^
 ||tracking.stihl.pt^
-||www.b2bmarketing.swisscom.ch^
 ||www.service.cz.nl^
 ||www.zakelijk.cz.nl^
 !
@@ -13407,8 +12175,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s983435340.hs.eloqua.com disguised trackers
 !
-||aarpannuity.newyorklife.com^
-||aarpfda.newyorklife.com^
 !
 !
 ||app.paciolan.com^
@@ -13443,7 +12209,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ||access.acspubs.org^
 ||cenbrandlab.acspubs.org^
-||eformsonboarding.globalbanking.wolterskluwer.com^
 ||eloqua.emdmillipore.com^
 ||eloqua.sigmaaldrich.com^
 ||feedback.avigilon.com^
@@ -13572,8 +12337,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1705637988.hs.eloqua.com disguised trackers
 !
-||email-tw.americanexpress.com^
-||sgforex.americanexpress.com^
 !
 !
 ||act.pbs.org^
@@ -13603,8 +12366,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s376572143.hs.eloqua.com disguised trackers
 !
-||actie.athlon.com^
-||service.athlon.com^
 !
 !
 ||action.hassconsult.co.ke^
@@ -13770,13 +12531,10 @@ charlestownwyllie.oaklawnnonantum.com^
 ||images.e.tcichemicals.com^
 ||images.e.transunion.com^
 ||images.e.tycois.com^
-||images.efficiency.nl.visma.com^
-||images.efficiency.visma.dk^
 ||images.efficiency.visma.no^
 ||images.em.email-prudential.com^
 ||images.em.thermofisher.com^
 ||images.email.air-worldwide.com^
-||images.email.hockeytown.com^
 ||images.email.wisdomtree.com^
 ||images.emails.bokfinancial.com^
 ||images.energysolutions.evergy.com^
@@ -13882,9 +12640,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s127477.hs.eloqua.com disguised trackers
 !
-||admin.smartgroup.com.au^
-||save.salary.com.au^
-||save.smartsalary.com.au^
 !
 !
 ||advise.gallup.com^
@@ -13906,7 +12661,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s831949997.hs.eloqua.com disguised trackers
 !
-||advise.gallup.com^
 !
 !
 ||advisorservicesfpc.etradefinancial.com^
@@ -13931,7 +12685,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s944935836.hs.eloqua.com disguised trackers
 !
-||advisorservicesfpc.etradefinancial.com^
 !
 !
 ||ae-go.experian.com^
@@ -13990,7 +12743,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||pr.prnewswire.com^
 ||response.iqpc.com^
 ||secureforms.xperthr.nl^
-||track.go.comres.emerson.com^
 ||tracking-explore-uat.agilent.com^
 ||tracking.columbiabank.com^
 ||tracking.singlestore.com^
@@ -14099,37 +12851,24 @@ charlestownwyllie.oaklawnnonantum.com^
 ! e74319.x.akamaiedge.net disguised trackers
 !
 ||alias.cloud-marketing.dimensiondata.com^
-||app.partner.fisglobal.com^
 ||assets.comunicaciones.pymas.com.co^
 ||cdn.experience.globalsources.com^
 ||eloquaimages.e.abb.com^
-||image.info.perkinelmer.com^
 ||imagenes.ubmmexico.com^
-||images.assets.aapa.org^
 ||images.blackhat.com^
 ||images.c.clearlink.com^
 ||images.cloud.travelport.com^
-||images.communication.carsales.com.au^
 ||images.createchange.uq.edu.au^
 ||images.demand.awspls.com^
 ||images.demand.brainshark.com^
 ||images.demand.nec.com^
-||images.discoveracademic.ptc.com^
-||images.e.bengals.com^
-||images.e.bulls.com^
-||images.e.chiefs.com^
 ||images.e.corenetglobal.org^
-||images.e.dallasstars.com^
 ||images.e.gallup.com^
-||images.e.royalmail.com^
 ||images.e.seagate.com^
-||images.e.seahawksemail.com^
-||www.assets.dialogue.signify.com^
 !
 ! s1109391453.hs.eloqua.com disguised trackers
 !
 ||alquiler.carflex.es^
-||renting.aldautomotive.es^
 !
 !
 ||altalex.wolterskluwer.com^
@@ -14155,9 +12894,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1661434605.hs.eloqua.com disguised trackers
 !
-||americasbrandperformancesupport.hilton.com^
-||bpsemea.hilton.com^
-||mec.hilton.com^
 !
 !
 ||connect.health.lexmed.com^
@@ -14192,15 +12928,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1844742678.hs.eloqua.com disguised trackers
 !
-||tracking.build.com^
-||tracking.faucet.com^
-||tracking.faucetdirect.com^
-||tracking.handlesets.com^
-||tracking.kegerator.com^
-||tracking.lightingdirect.com^
-||tracking.pullsdirect.com^
-||tracking.ventingdirect.com^
-||tracking.winecoolerdirect.com^
 !
 !
 ||anmeldung.promatis.ch^
@@ -14245,8 +12972,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1770571578.hs.eloqua.com disguised trackers
 !
-||answers.teradata.com^
-||answers.teradata.fr^
 ||answers.teradata.in^
 !
 !
@@ -14267,7 +12992,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s389462.hs.eloqua.com disguised trackers
 !
-||ap.quadient.com^
 !
 !
 ||apac.adpinfo.com^
@@ -14282,12 +13006,10 @@ charlestownwyllie.oaklawnnonantum.com^
 ||elq.opensource.com^
 ||elq.redhat.com^
 ||etrack.ext.hpe.com^
-||fr.secure.sonosite.com^
 ||ghp.adp.ca^
 ||hr.adp.ca^
 ||info.adp.com^
 ||info.reutersagency.com^
-||kr.secure.sonosite.com^
 ||learn.relationshipone.com^
 ||motm.adp.ca^
 ||nas.adpinfo.com^
@@ -14300,7 +13022,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||tracking.fr.adp.com^
 ||trk.advisory.com^
 ||www.adpinfo.com^
-||www.domorewithless.adp.ca^
 ||www.infos-experts.adp.com^
 !
 !
@@ -14423,11 +13144,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ! s1013191099.hs.eloqua.com disguised trackers
 !
 ||campaign.motorolasolutions.com^
-||campaigninfo.motorolasolutions.com^
-||lacinfo.motorolasolutions.com^
-||namrinfo.motorolasolutions.com^
-||preference.motorolasolutions.com^
-||tracking.motorolasolutions.com^
 !
 !
 ||app.nhra.com^
@@ -14482,7 +13198,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1016221.hs.eloqua.com disguised trackers
 !
-||app.arts.uci.edu^
 !
 !
 ||app.augustaentertainmentcomplex.com^
@@ -14497,7 +13212,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||communication.ricoh.de^
 ||consulting.icmi.com^
 ||content-datacenter.hello.global.ntt^
-||dev.marketing.championhomes.com^
 ||digitalworkplace.ricoh.fr^
 ||discover.jll.com^
 ||email-ap.jll.co.in^
@@ -14528,7 +13242,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||track.info.optometryadvisor.com^
 ||track.info.rarediseaseadvisor.com^
 ||track.info.rheumatologyadvisor.com^
-||tracking.go.provident.bank^
 ||tracking.seakeeper.com^
 ||trk.mktg.nec.com^
 ||workplace.ricoh.co.uk^
@@ -14664,8 +13377,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s600830862.hs.eloqua.com disguised trackers
 !
-||app.engage.richardsonrfpd.com^
-||images.engage.richardsonrfpd.com^
 !
 !
 ||app.mgoblue.com^
@@ -14688,43 +13399,33 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s296651.hs.eloqua.com disguised trackers
 !
-||app.fightingillini.com^
-||t.fightingillini.com^
 !
 ! s215151.hs.eloqua.com disguised trackers
 !
-||app.godeacs.com^
 !
 ! s1107655.hs.eloqua.com disguised trackers
 !
-||app.goheels.com^
 !
 ! s1281471.hs.eloqua.com disguised trackers
 !
-||t.gohuskies.com^
 !
 ! s54006.hs.eloqua.com disguised trackers
 !
-||t.gopack.com^
 !
 ! s1457279.hs.eloqua.com disguised trackers
 !
-||t.gopsusports.com^
 !
 ! s42415.hs.eloqua.com disguised trackers
 !
-||t.hailstate.com^
 !
 ! s2977661.hs.eloqua.com disguised trackers
 !
-||t.hokiesports.com^
 !
 ! s1550576449.hs.eloqua.com disguised trackers
 !
 !
 ! s274.hs.eloqua.com disguised trackers
 !
-||app.innovation.nuance.com^
 !
 !
 ||app.kstatesports.com^
@@ -14755,75 +13456,50 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s347007.hs.eloqua.com disguised trackers
 !
-||app.mgoblue.com^
-||t.mgoblue.com^
 !
 ! s808240.hs.eloqua.com disguised trackers
 !
-||t.miamihurricanes.com^
 !
 ! s1260946616.hs.eloqua.com disguised trackers
 !
-||t.mktg.genesys.com^
-||tkelq.genesys.com^
 !
 ! s3690781.hs.eloqua.com disguised trackers
 !
-||app.nhra.com^
-||t.nhra.com^
 !
 ! s1480.hs.eloqua.com disguised trackers
 !
-||now.cumminsfiltration.com^
-||rsvp.cummins.com^
 !
 ! s1552085.hs.eloqua.com disguised trackers
 !
 ||app.pbr.com^
-||t.pbr.com^
 !
 ! s756589.hs.eloqua.com disguised trackers
 !
-||app.purduesports.com^
-||t.purduesports.com^
 !
 ! s94142.hs.eloqua.com disguised trackers
 !
-||t.rolltide.com^
 !
 ! s8100632.hs.eloqua.com disguised trackers
 !
-||t.scarletknights.com^
 !
 ! s1241071892.hs.eloqua.com disguised trackers
 !
-||app.siemens-energy.com^
 !
 ! s1575097598.hs.eloqua.com disguised trackers
 !
-||trail.sweetandmaxwell.co.uk^
-||trail.thomsonreuters.ca^
-||trail.thomsonreuters.co.uk^
-||trail.thomsonreuters.com^
 !
 ! s1701211846.hs.eloqua.com disguised trackers
 !
 !
 ! s2119850.hs.eloqua.com disguised trackers
 !
-||t.usctrojans.com^
 !
 ! s2081649.hs.eloqua.com disguised trackers
 !
-||t.xlcenter.com^
 !
 ! s1271891940.hs.eloqua.com disguised trackers
 !
-||application.ricoh.co.za^
 ||bps.ricoh.co.uk^
-||itservices.ricoh.co.uk^
-||onlineshop.ricoh.co.uk^
-||tools.ricoh.co.uk^
 !
 !
 ||asia.interface.com^
@@ -14856,36 +13532,19 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s937.hs.eloqua.com disguised trackers
 !
-||ast-fr.adp.ca^
-||ghp.adp.ca^
-||hr.adp.ca^
-||info.adp.com^
-||motm.adp.ca^
-||nas.adpinfo.com^
-||secure.adp.ca^
-||subscribe.adpinfo.com^
-||tracking.adp-iat.adp.ca^
-||tracking.au.adp.com^
-||tracking.events.adp.com^
-||tracking.fr.adp.com^
-||www.domorewithless.adp.ca^
-||www.infos-experts.adp.com^
 !
 ! s1038638438.hs.eloqua.com disguised trackers
 !
 ||immunocap.thermofisher.com^
-||isac.thermofisher.com^
 !
 ! s883680860.hs.eloqua.com disguised trackers
 !
 !
 ! s522772699.hs.eloqua.com disguised trackers
 !
-||b.bloomberglp.com^
 !
 ! s182847396.hs.eloqua.com disguised trackers
 !
-||www.b2bmarketing.swisscom.ch^
 !
 !
 ||business-pages.edfenergy.com^
@@ -14910,16 +13569,9 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1965211.hs.eloqua.com disguised trackers
 !
-||tracking.selective.com^
 !
 ! s2448.hs.eloqua.com disguised trackers
 !
-||bg-go.experian.com^
-||fr-go.experian.com^
-||jp-go.experian.com^
-||se-go.experian.com^
-||th-go.experian.com^
-||us-go.experian.com^
 !
 ! s1425463959.hs.eloqua.com disguised trackers
 !
@@ -14930,7 +13582,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s3856805.hs.eloqua.com disguised trackers
 !
-||business-pages.edfenergy.com^
 !
 ! s188599536.hs.eloqua.com disguised trackers
 !
@@ -14945,15 +13596,9 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1525.hs.eloqua.com disguised trackers
 !
-||in-business.vodafone.com^
-||iot-mktg.vodafone.com^
-||it-mktg.vodafone.com^
-||tracking.vodafone.co.uk^
 !
 ! s1325.hs.eloqua.com disguised trackers
 !
-||businessmaking.progress.com^
-||forms.progress.com^
 !
 ! s1019741931.hs.eloqua.com disguised trackers
 !
@@ -14974,11 +13619,9 @@ charlestownwyllie.oaklawnnonantum.com^
 ||tracking.scoresandodds.com^
 ||tracking.smartbets.com^
 ||tracking.wettfreunde.net^
-||www.enterprises.proximus.be^
 !
 ! s266319173.hs.eloqua.com disguised trackers
 !
-||campaign.amadeus.com^
 !
 !
 ||campaign.vendorpedia.com^
@@ -15009,10 +13652,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s477278796.hs.eloqua.com disguised trackers
 !
-||campaign.fr.mazda.be^
-||dialogue.mazda.bg^
-||dialogue.mazda.gr^
-||dialogue.mazda.rs^
 !
 ! s128650407.hs.eloqua.com disguised trackers
 !
@@ -15021,8 +13660,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s2025046056.hs.eloqua.com disguised trackers
 !
-||fpc.onetrust.com^
-||info.onetrust.com^
 !
 ! s598301108.hs.eloqua.com disguised trackers
 !
@@ -15035,20 +13672,15 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1363.hs.eloqua.com disguised trackers
 !
-||event.shl.com^
-||events.engage.cebglobal.com^
-||tracking.shl.com^
 !
 ! s1754.hs.eloqua.com disguised trackers
 !
-||campaigns.netscout.com^
 !
 ! s1783.hs.eloqua.com disguised trackers
 !
 !
 ! s1856564273.hs.eloqua.com disguised trackers
 !
-||care.stlukes-stl.com^
 !
 !
 ||connect.chamberlain.edu^
@@ -15107,11 +13739,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1737033466.hs.eloqua.com disguised trackers
 !
-||events.avaya.com^
-||governmentcloud.avaya.com^
-||info.avaya.com^
-||partners.avaya.com^
-||simple.avaya.com^
 !
 ! s522558593.hs.eloqua.com disguised trackers
 !
@@ -15121,13 +13748,9 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1439730185.hs.eloqua.com disguised trackers
 !
-||channelportal.netsuite.com^
-||mkto.bronto.com^
-||tracking.netsuite.com^
 !
 ! s740070409.hs.eloqua.com disguised trackers
 !
-||choose.adelaide.edu.au^
 !
 ! s1015724034.hs.eloqua.com disguised trackers
 !
@@ -15148,15 +13771,12 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s840.hs.eloqua.com disguised trackers
 !
-||clicks.tableau.com^
 !
 ! s2104.hs.eloqua.com disguised trackers
 !
-||cm.informaengage.com^
 !
 ! s1006495326.hs.eloqua.com disguised trackers
 !
-||comms.supplychain.nhs.uk^
 !
 ! s457207082.hs.eloqua.com disguised trackers
 !
@@ -15172,18 +13792,13 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s2650.hs.eloqua.com disguised trackers
 !
-||lewin.optum.com^
 !
 ! s1184.hs.eloqua.com disguised trackers
 !
-||connect-qa.netapp.com^
-||connect.abm.netapp.com^
 ||connect.partner-connect.netapp.com^
 !
 ! s1150279252.hs.eloqua.com disguised trackers
 !
-||webtracking.acams.org^
-||webtracking.moneylaundering.com^
 !
 ! s2144.hs.eloqua.com disguised trackers
 !
@@ -15191,83 +13806,54 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1609254285.hs.eloqua.com disguised trackers
 !
-||connect.chapman.com^
 !
 ! s462232510.hs.eloqua.com disguised trackers
 !
-||log.cognex.com^
 !
 ! s2190102.hs.eloqua.com disguised trackers
 !
-||tracking.connect.services.global.ntt^
 !
 ! s703561.hs.eloqua.com disguised trackers
 !
-||connect.fwd.hcahealthcare.com^
 !
 ! s57532.hs.eloqua.com disguised trackers
 !
-||connect.health.bjc.org^
-||tracking.health.bjc.org^
 !
 ! s626391.hs.eloqua.com disguised trackers
 !
-||connect.health.lexmed.com^
-||tracking.health.lexmed.com^
 !
 ! s4805455.hs.eloqua.com disguised trackers
 !
-||connect.healthcare.northbay.org^
-||web.healthcare.northbay.org^
 !
 ! s1354.hs.eloqua.com disguised trackers
 !
-||connect.intercall.com^
-||safety.west.com^
 !
 ! s722592.hs.eloqua.com disguised trackers
 !
-||connect.labcorp.com^
-||tracking1.labcorp.com^
 !
 ! s619564847.hs.eloqua.com disguised trackers
 !
-||connect.methodisthealthsystem.org^
-||tracking.info.methodisthealthsystem.org^
 !
 ! s978103.hs.eloqua.com disguised trackers
 !
-||connect.ncd.hcahealthcare.com^
 !
 ! s2288812.hs.eloqua.com disguised trackers
 !
-||connect.nfd.hcahealthcare.com^
 !
 ! s921859.hs.eloqua.com disguised trackers
 !
-||connect.ntx.hcahealthcare.com^
 !
 ! s1485599638.hs.eloqua.com disguised trackers
 !
 !
 ! s3292856.hs.eloqua.com disguised trackers
 !
-||tracking.stihl.be^
-||tracking.stihl.de^
-||tracking.stihl.es^
-||tracking.stihl.fr^
-||tracking.stihl.lu^
-||tracking.stihl.nl^
-||tracking.stihl.pt^
 !
 ! s1879417329.hs.eloqua.com disguised trackers
 !
-||connectfpc.zebra.com^
-||trust.zebra.com^
 !
 ! s1236759688.hs.eloqua.com disguised trackers
 !
-||connect2.secureforms.mcafee.com^
 !
 ! s609785623.hs.eloqua.com disguised trackers
 !
@@ -15277,13 +13863,9 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s2090192166.hs.eloqua.com disguised trackers
 !
-||consulting.guidehouse.com^
-||tracking.guidehouse.com^
-||tracking.navigant.com^
 !
 ! s695499979.hs.eloqua.com disguised trackers
 !
-||subscription.coface.com^
 !
 ! p02g.hs.eloqua.com disguised trackers
 !
@@ -15300,27 +13882,21 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1165.hs.eloqua.com disguised trackers
 !
-||contactforms.53.com^
 !
 ! s287749648.hs.eloqua.com disguised trackers
 !
 !
 ! s1240377118.hs.eloqua.com disguised trackers
 !
-||contactus.53.com^
-||insights.53.com^
-||subscriptionmanagement.53.com^
 !
 ! s1521.hs.eloqua.com disguised trackers
 !
-||securetracking.eaton.com^
 !
 ! s680149.hs.eloqua.com disguised trackers
 !
 !
 ! s338644260.hs.eloqua.com disguised trackers
 !
-||contents.pwc.com^
 !
 !
 ||future.uwindsor.ca^
@@ -15350,24 +13926,18 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s676.hs.eloqua.com disguised trackers
 !
-||ctc.wolterskluwer.com^
 !
 ! s1086385399.hs.eloqua.com disguised trackers
 !
 !
 ! s2082.hs.eloqua.com disguised trackers
 !
-||cyber.boozallen.com^
-||info.boozallen.com^
-||missions.boozallen.com^
 !
 ! s2826.hs.eloqua.com disguised trackers
 !
-||tracking.ptc.com^
 !
 ! s554290.hs.eloqua.com disguised trackers
 !
-||dev.marketing.championhomes.com^
 !
 ! s1097967772.hs.eloqua.com disguised trackers
 !
@@ -15377,27 +13947,18 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1981585949.hs.eloqua.com disguised trackers
 !
-||digital.att.com^
-||explore.att.com^
-||site.att.com^
 !
 ! s1669161669.hs.eloqua.com disguised trackers
 !
-||digital.cloud.travelport.com^
 !
 ! s833068.hs.eloqua.com disguised trackers
 !
-||discover.averydennison.com^
-||tracking.averydennison.com^
 !
 ! s786780033.hs.eloqua.com disguised trackers
 !
-||tracking.clarivate.com^
 !
 ! s899.hs.eloqua.com disguised trackers
 !
-||discover.harvardbusiness.org^
-||insights.harvardbusiness.org^
 !
 ! s1819831755.hs.eloqua.com disguised trackers
 !
@@ -15410,7 +13971,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s840921098.hs.eloqua.com disguised trackers
 !
-||e.relacionamento.serasaexperian.com.br^
 !
 ! s672742760.hs.eloqua.com disguised trackers
 !
@@ -15420,42 +13980,21 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1343588892.hs.eloqua.com disguised trackers
 !
-||go.visma.com^
-||suunta.visma.fi^
-||tracking.dataloen.dk^
-||tracking.exso.no^
-||tracking.visma.com^
-||tracking.visma.dk^
-||tracking.visma.lv^
-||tracking.visma.no^
-||tracking.vismaraet.nl^
-||visma.e-conomic.dk^
 !
 ! s418514676.hs.eloqua.com disguised trackers
 !
-||electronics.edm.globalsources.com^
-||gslive.edm.globalsources.com^
-||gsmatch.edm.globalsources.com^
-||gsols.edm.globalsources.com^
-||lifestyle.tradeshow.globalsources.com^
-||mobile-electronics.edm.globalsources.com^
-||summit.edm.globalsources.com^
-||tradeshow.edm.globalsources.com^
 !
 ! s936847217.hs.eloqua.com disguised trackers
 !
-||eloqua-tracking.kaiserpermanente.org^
 !
 ! s795651218.hs.eloqua.com disguised trackers
 !
 !
 ! s359022900.hs.eloqua.com disguised trackers
 !
-||eloqua-uat.motorolasolutions.com^
 !
 ! s832461399.hs.eloqua.com disguised trackers
 !
-||eloqua.emdmillipore.com^
 !
 ! s1009272243.hs.eloqua.com disguised trackers
 !
@@ -15465,18 +14004,15 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s2049007180.hs.eloqua.com disguised trackers
 !
-||gocertiport.pearsonvue.com^
 !
 ! s978087.hs.eloqua.com disguised trackers
 !
 !
 ! s351095147.hs.eloqua.com disguised trackers
 !
-||eloquamarketing.masterlock.com^
 !
 ! s460529241.hs.eloqua.com disguised trackers
 !
-||secure.constellation.iqvia.com^
 !
 ! s155608312.hs.eloqua.com disguised trackers
 !
@@ -15487,36 +14023,25 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s584437826.hs.eloqua.com disguised trackers
 !
-||elq-tracking.genomes.atcc.org^
 ||tracking.go.atcc.org^
 !
 ! s538756640.hs.eloqua.com disguised trackers
 !
-||getinfo.fullsail.edu^
 !
 ! s1535.hs.eloqua.com disguised trackers
 !
-||secureforms.accuity.com^
 !
 ! s1548954099.hs.eloqua.com disguised trackers
 !
-||elq.analog.com^
 !
 ! s1795.hs.eloqua.com disguised trackers
 !
-||elq.ansible.com^
-||elq.enterprisersproject.com^
-||elq.openshift.com^
-||elq.opensource.com^
-||elq.redhat.com^
 !
 ! s161752090.hs.eloqua.com disguised trackers
 !
-||go.blackrock.com^
 !
 ! s1634.hs.eloqua.com disguised trackers
 !
-||secureforms.flightglobal.com^
 !
 ! s332.hs.eloqua.com disguised trackers
 !
@@ -15532,29 +14057,24 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1616.hs.eloqua.com disguised trackers
 !
-||elq.lansa.com^
 !
 ! s2213.hs.eloqua.com disguised trackers
 !
 !
 ! s484374275.hs.eloqua.com disguised trackers
 !
-||elq.nextens.nl^
 !
 ! s373.hs.eloqua.com disguised trackers
 !
 !
 ! s301091484.hs.eloqua.com disguised trackers
 !
-||tracking.utas.edu.au^
 !
 ! s1849907385.hs.eloqua.com disguised trackers
 !
-||research.gartner.com^
 !
 ! s1168626303.hs.eloqua.com disguised trackers
 !
-||elqapp.timewarnercable.com^
 !
 ! s1194310.hs.eloqua.com disguised trackers
 !
@@ -15564,7 +14084,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1555122525.hs.eloqua.com disguised trackers
 !
-||go.hitachienergy.com^
 !
 ! s174746480.hs.eloqua.com disguised trackers
 !
@@ -15577,7 +14096,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1250714985.hs.eloqua.com disguised trackers
 !
-||event.victorops.com^
 !
 ! s128040577.hs.eloqua.com disguised trackers
 !
@@ -15587,110 +14105,34 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1258972516.hs.eloqua.com disguised trackers
 !
-||elqtrk.cn.morningstar.com^
-||elqtrk.hk.morningstar.com^
-||elqtrk.morningstar.com^
-||elqtrk.my.morningstar.com^
 !
 ! s334284386.hs.eloqua.com disguised trackers
 !
-||elqtrk.intel.com.au^
-||elqtrk.intel.com.br^
-||elqtrk.intel.com.tr^
-||elqtrk.intel.com.tw^
-||elqtrk.intel.de^
-||elqtrk.intel.es^
-||elqtrk.intel.fr^
-||elqtrk.intel.in^
-||elqtrk.intel.it^
-||elqtrk.intel.la^
-||elqtrk.intel.pl^
-||elqtrk.intel.ru^
-||elqtrk.intel.sg^
-||elqtrk.thailand.intel.com^
-||intelpartneralliance.intel.com^
-||plan.seek.intel.com^
-||software.seek.intel.com^
 ||techprovider.intel.com^
-||webinar.intel.com^
 !
 ! s298548211.hs.eloqua.com disguised trackers
 !
-||els298548211.medtronic.com^
-||www.medtronicsolutions.com^
 !
 ! s65254455.hs.eloqua.com disguised trackers
 !
-||email-am.jll.com.co^
-||email-am.us.jll.com^
 !
 ! s362000045.hs.eloqua.com disguised trackers
 !
-||email-ap.jll.co.in^
-||email-ap.jll.pe^
 !
 ! s1365483532.hs.eloqua.com disguised trackers
 !
-||email.hockeytown.com^
 !
 ! s616291841.hs.eloqua.com disguised trackers
 !
-||email.lottehotel.com^
 !
 ! s1742027581.hs.eloqua.com disguised trackers
 !
-||emea.info.mouser.com^
-||sub.info.mouser.com^
 !
 ! s290512336.hs.eloqua.com disguised trackers
 !
-||engage-emea.jll.com^
 !
 ! s837031577.hs.eloqua.com disguised trackers
 !
-||engage.3m.co.cr^
-||engage.3m.co.kr^
-||engage.3m.co.th^
-||engage.3m.co.uk^
-||engage.3m.co.za^
-||engage.3m.com.ar^
-||engage.3m.com.au^
-||engage.3m.com.bo^
-||engage.3m.com.br^
-||engage.3m.com.cn^
-||engage.3m.com.co^
-||engage.3m.com.do^
-||engage.3m.com.ec^
-||engage.3m.com.es^
-||engage.3m.com.gt^
-||engage.3m.com.hk^
-||engage.3m.com.jm^
-||engage.3m.com.ni^
-||engage.3m.com.tr^
-||engage.3m.com.tt^
-||engage.3m.com.tw^
-||engage.3m.com.uy^
-||engage.3maustria.at^
-||engage.3mbulgaria.bg^
-||engage.3mcanada.ca^
-||engage.3mchile.cl^
-||engage.3mcompany.jp^
-||engage.3mdeutschland.de^
-||engage.3megypt.com.eg^
-||engage.3mfrance.fr^
-||engage.3mhellas.gr^
-||engage.3mindia.in^
-||engage.3misrael.co.il^
-||engage.3mitalia.it^
-||engage.3mmagyarorszag.hu^
-||engage.3mmaroc.ma^
-||engage.3mnederland.nl^
-||engage.3mnz.co.nz^
-||engage.3mphilippines.com.ph^
-||engage.3mpolska.pl^
-||engage.3msuomi.fi^
-||engage.3msverige.se^
-||info.engage.3m.com^
 !
 ! p07g.hs.eloqua.com disguised trackers
 !
@@ -15698,7 +14140,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1535023188.hs.eloqua.com disguised trackers
 !
-||engage.unisa.edu.au^
 !
 ! p07c.hs.eloqua.com disguised trackers
 !
@@ -15712,178 +14153,121 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s661931745.hs.eloqua.com disguised trackers
 !
-||engage.uq.edu.au^
 !
 ! s177775138.hs.eloqua.com disguised trackers
 !
-||engage2demand.cisco.com^
-||engagemetrics.cisco.com^
 !
 ! s1636063769.hs.eloqua.com disguised trackers
 !
-||enterprises.proximus.be^
-||www.enterprises.proximus.be^
 !
 ! s479233787.hs.eloqua.com disguised trackers
 !
-||eqclicks.movember.com^
 !
 ! s113755760.hs.eloqua.com disguised trackers
 !
-||eqs.intuit.com^
 !
 ! s94443966.hs.eloqua.com disguised trackers
 !
-||eroar.lionsclubs.org^
 !
 ! s704917861.hs.eloqua.com disguised trackers
 !
-||etrack.ext.arubainstanton.com^
-||etrack.ext.arubanetworks.com^
 !
 ! s2048.hs.eloqua.com disguised trackers
 !
-||etrack.ext.hpe.com^
 !
 ! s639.hs.eloqua.com disguised trackers
 !
-||ets.ni.com^
 !
 ! s1236288378.hs.eloqua.com disguised trackers
 !
-||event.clubcorp.com^
 !
 ! s1791556376.hs.eloqua.com disguised trackers
 !
-||events.georgiancollege.ca^
 !
 ! s672.hs.eloqua.com disguised trackers
 !
-||events.interface.com^
 !
 ! s1411.hs.eloqua.com disguised trackers
 !
-||events.lexmark.com^
 !
 ! s477300880.hs.eloqua.com disguised trackers
 !
-||events.oddo-bhf.com^
 !
 ! s680451474.hs.eloqua.com disguised trackers
 !
-||evkeeza-e.regeneron.com^
 !
 ! s1885735477.hs.eloqua.com disguised trackers
 !
-||experience.jcu.edu.au^
-||study.jcu.edu.au^
 !
 ! s1775412872.hs.eloqua.com disguised trackers
 !
-||experience.rsm.com.au^
 !
 ! s1044706121.hs.eloqua.com disguised trackers
 !
-||experiencia.coopecaja.fi.cr^
 !
 ! s1107300821.hs.eloqua.com disguised trackers
 !
-||explore.agilent.com^
 !
 ! s1658862228.hs.eloqua.com disguised trackers
 !
-||explore.epsilon.com^
-||tracking.epsilon.com^
 !
 ! s240978839.hs.eloqua.com disguised trackers
 !
-||explore.studyperth.com.au^
 !
 ! s61088445.hs.eloqua.com disguised trackers
 !
-||feedback.avigilon.com^
-||fpc.avigilon.com^
-||fpc.indigovision.com^
-||fpc.pelco.com^
 ||info.avigilon.com^
-||pages.indigovision.com^
-||pages.pelco.com^
 !
 ! s1056287425.hs.eloqua.com disguised trackers
 !
-||feedback.vegasgoldenknights.com^
 !
 ! s1746211102.hs.eloqua.com disguised trackers
 !
-||firstparty1.dentsplysirona.com^
 !
 ! s1278131127.hs.eloqua.com disguised trackers
 !
-||flavors.firmenich.com^
-||investors.firmenich.com^
 !
 ! s1251203807.hs.eloqua.com disguised trackers
 !
-||forms.bmc.com^
 !
 ! s698935272.hs.eloqua.com disguised trackers
 !
-||fpc.acpinternist.org^
-||www.acpprograms.org^
 !
 ! s868742820.hs.eloqua.com disguised trackers
 !
-||fpc.broadway.com^
-||shows.broadwayacrossamerica.com^
 !
 ! s154878491.hs.eloqua.com disguised trackers
 !
-||fpc.gartner.com^
 !
 ! s2008141379.hs.eloqua.com disguised trackers
 !
-||fpc.laerdal.com^
 !
 ! s84780736.hs.eloqua.com disguised trackers
 !
-||fpc.pelican.com^
 !
 ! s1265708786.hs.eloqua.com disguised trackers
 !
-||fpc.sage.com^
-||get.sage.com^
 !
 ! s295390938.hs.eloqua.com disguised trackers
 !
-||fpc.seahawks.com^
 !
 ! s652089797.hs.eloqua.com disguised trackers
 !
-||fpc.trimarkusa.com^
 !
 ! s1929339847.hs.eloqua.com disguised trackers
 !
-||fpcdallasstars.nhl.com^
 !
 ! s944086489.hs.eloqua.com disguised trackers
 !
-||fpcsbulls.nba.com^
 !
 ! s1157.hs.eloqua.com disguised trackers
 !
-||fr.secure.sonosite.com^
-||kr.secure.sonosite.com^
-||secure.sonosite.com^
 !
 ! s1709896.hs.eloqua.com disguised trackers
 !
-||funding.go.apprenticeshipcommunity.com.au^
 !
 ! s127504789.hs.eloqua.com disguised trackers
 !
-||future.uwindsor.ca^
-||learn.uwindsor.ca^
-||tracking.uwindsor.ca^
 !
 !
 ||gba.kwm.com^
@@ -15892,70 +14276,45 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s7468769.hs.eloqua.com disguised trackers
 !
-||gba.kwm.com^
-||pages.kwm.com^
 !
 ! s788658067.hs.eloqua.com disguised trackers
 !
-||gbl.radware.com^
 !
 ! s1053984823.hs.eloqua.com disguised trackers
 !
-||gcn.tuv.com^
-||go.tuv.com^
 !
 ! s804077455.hs.eloqua.com disguised trackers
 !
-||gdg.gardnerdenver.com^
 !
 ! s1763.hs.eloqua.com disguised trackers
 !
-||get.kronos.com^
-||get.ukg.ca^
-||get.ukg.com.au^
-||get.ukg.mx^
-||www.get.ukg.com^
 !
 ! s3104.hs.eloqua.com disguised trackers
 !
-||getmore.enelx.com^
 !
 ! s335973.hs.eloqua.com disguised trackers
 !
-||global-mktg.transunion.com^
 !
 ! s616.hs.eloqua.com disguised trackers
 !
-||globalbanking.wolterskluwer.com^
 !
 ! s773611208.hs.eloqua.com disguised trackers
 !
-||globalcustodian.strategic-i.com^
 !
 ! s903.hs.eloqua.com disguised trackers
 !
-||globalsolutions.risk.lexisnexis.com^
-||tracking.risk.lexisnexis.com^
-||tracking.risk.lexisnexis.com.br^
 !
 ! s2376.hs.eloqua.com disguised trackers
 !
-||go.blackboard.com^
-||tracking.blackboard.com^
 !
 ! s1061282284.hs.eloqua.com disguised trackers
 !
-||go.blackducksoftware.com^
 !
 ! s1424104964.hs.eloqua.com disguised trackers
 !
-||go.bloombergindustry.com^
-||tracking.bloombergindustry.com^
-||tracking.pro.bloombergtax.com^
 !
 ! s1012247495.hs.eloqua.com disguised trackers
 !
-||go.century21.fr^
 !
 ! s5448495.hs.eloqua.com disguised trackers
 !
@@ -15964,26 +14323,18 @@ charlestownwyllie.oaklawnnonantum.com^
 ! s1409029440.hs.eloqua.com disguised trackers
 !
 ||go.climate.emerson.com^
-||go.comres.emerson.com^
-||go.proteam.emerson.com^
-||go.ridgid.emerson.com^
-||track.go.comres.emerson.com^
 !
 ! s1983452.hs.eloqua.com disguised trackers
 !
-||go.comcastspectacor.com^
 !
 ! s1739541848.hs.eloqua.com disguised trackers
 !
-||go.computacenter.com^
 !
 ! s1161.hs.eloqua.com disguised trackers
 !
-||go.deltek.com^
 !
 ! s4010901.hs.eloqua.com disguised trackers
 !
-||go.econnect.dellmed.utexas.edu^
 !
 ! p02a.hs.eloqua.com disguised trackers
 !
@@ -15991,91 +14342,66 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1155674399.hs.eloqua.com disguised trackers
 !
-||go.edmontonoilers.com^
 !
 ! s958641.hs.eloqua.com disguised trackers
 !
-||go.emeadatacenter.services.global.ntt^
-||trk.emeadatacenter.services.global.ntt^
 !
 ! s367589339.hs.eloqua.com disguised trackers
 !
-||go.emersonautomation.com^
 !
 ! s1783419991.hs.eloqua.com disguised trackers
 !
-||go.enautics.com^
 !
 ! s1704464.hs.eloqua.com disguised trackers
 !
-||go.fhlbny.com^
 !
 ! s634881558.hs.eloqua.com disguised trackers
 !
-||go.firstderivatives.com^
 !
 ! s1068280789.hs.eloqua.com disguised trackers
 !
-||go.fuze.com^
 !
 ! s5139842.hs.eloqua.com disguised trackers
 !
-||go.info.verifi.com^
 !
 ! s638200148.hs.eloqua.com disguised trackers
 !
-||go.l-com.com^
 !
 ! s1973398186.hs.eloqua.com disguised trackers
 !
-||go.oracle.com^
 !
 ! s97097.hs.eloqua.com disguised trackers
 !
-||go.provident.bank^
-||tracking.go.provident.bank^
 !
 ! s2118877368.hs.eloqua.com disguised trackers
 !
-||go.psentertainment.com^
 !
 ! s1372514231.hs.eloqua.com disguised trackers
 !
-||go.sgs.com^
-||stats.sgs.com^
 !
 ! s2136619493.hs.eloqua.com disguised trackers
 !
-||go.zendesk.com^
 !
 ! s646005169.hs.eloqua.com disguised trackers
 !
-||go2.mathworks.com^
 !
 ! s1594690046.hs.eloqua.com disguised trackers
 !
-||go5.global.toshiba^
 !
 ! s1865390481.hs.eloqua.com disguised trackers
 !
-||grow.national.biz^
 !
 ! s1311950425.hs.eloqua.com disguised trackers
 !
-||gsasolutionssecure.gsa.gov^
 !
 ! s2108654627.hs.eloqua.com disguised trackers
 !
-||healthcare.questdiagnostics.com^
 !
 ! s1833705806.hs.eloqua.com disguised trackers
 !
-||hello.bpost.be^
 !
 ! s1399701292.hs.eloqua.com disguised trackers
 !
-||hopeful.coh.org^
-||response.coh.org^
 !
 ! secure.p04.eloqua.com disguised trackers
 !
@@ -16083,7 +14409,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1792984.hs.eloqua.com disguised trackers
 !
-||info.airborn.com^
 !
 ! s397286491.hs.eloqua.com disguised trackers
 !
@@ -16092,11 +14417,9 @@ charlestownwyllie.oaklawnnonantum.com^
 ! s273075935.hs.eloqua.com disguised trackers
 !
 ||info.arp.com^
-||service.bechtle.com^
 !
 ! s986383348.hs.eloqua.com disguised trackers
 !
-||info.authorize.net^
 !
 ! s1874466.hs.eloqua.com disguised trackers
 !
@@ -16104,462 +14427,310 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s906.hs.eloqua.com disguised trackers
 !
-||info.brightcove.com^
 !
 ! s769142976.hs.eloqua.com disguised trackers
 !
-||info.christus.mx^
 !
 ! s1556.hs.eloqua.com disguised trackers
 !
-||info.clarivate.com^
 !
 ! s517069690.hs.eloqua.com disguised trackers
 !
-||info.commercial.keurig.com^
 !
 ! s1054571203.hs.eloqua.com disguised trackers
 !
-||info.dfinsolutions.com^
 !
 ! s1482233545.hs.eloqua.com disguised trackers
 !
-||info.fdbhealth.com^
 ||tracking.fdbhealth.com^
 !
 ! s839961370.hs.eloqua.com disguised trackers
 !
-||info.fishersci.com^
 !
 ! s141717539.hs.eloqua.com disguised trackers
 !
-||info.hmisrael.co.il^
 !
 ! s1779773941.hs.eloqua.com disguised trackers
 !
-||info.houzz.com^
 !
 ! s4793349.hs.eloqua.com disguised trackers
 !
-||info.laley.es^
-||stat.juridicas.com^
-||stat.laley.es^
-||stat.laleynext.es^
-||stat.wolterskluwer.es^
-||stat.wolterskluwer.pt^
 !
 ! s1219509997.hs.eloqua.com disguised trackers
 !
-||info.macktrucks.com^
 !
 ! s208914684.hs.eloqua.com disguised trackers
 !
-||info.markmonitor.com^
 !
 ! s1492372420.hs.eloqua.com disguised trackers
 !
-||info.onemedical.com^
 !
 ! s1674556495.hs.eloqua.com disguised trackers
 !
-||info.perkinelmer.com^
 !
 ! s1017189481.hs.eloqua.com disguised trackers
 !
-||info.proedge.pwc.com^
 !
 ! s2124157686.hs.eloqua.com disguised trackers
 !
-||info.reutersagency.com^
 !
 ! s679701162.hs.eloqua.com disguised trackers
 !
-||info.scorecardrewards.com^
-||pp.scorecardrewards.com^
 !
 ! s258238139.hs.eloqua.com disguised trackers
 !
-||info.shavve.co.il^
 !
 ! s645819469.hs.eloqua.com disguised trackers
 !
-||info.sunsentinelmediagroup.com^
 !
 ! s642.hs.eloqua.com disguised trackers
 !
-||info.thermofisher.com^
 !
 ! s302289644.hs.eloqua.com disguised trackers
 !
-||info.unis.edu.gt^
 !
 ! s1788.hs.eloqua.com disguised trackers
 !
-||info1.thermofisher.com^
 !
 ! s1474118247.hs.eloqua.com disguised trackers
 !
-||info3.thermofisher.com^
 !
 ! s1988571858.hs.eloqua.com disguised trackers
 !
-||inform.janssenpro.eu^
-||tracking.janssenmedicalcloud.de^
 !
 ! s3243454.hs.eloqua.com disguised trackers
 !
-||information.lgcns.com^
 !
 ! s741846630.hs.eloqua.com disguised trackers
 !
-||ins.leavitt.com^
 !
 ! s1706134858.hs.eloqua.com disguised trackers
 !
-||insight.business.hsbc.com^
 !
 ! s1178718692.hs.eloqua.com disguised trackers
 !
-||insights.ddiworld.com^
 !
 ! s1503422690.hs.eloqua.com disguised trackers
 !
-||insurance.alliant.com^
 !
 ! s1127287735.hs.eloqua.com disguised trackers
 !
-||ixia-elq.keysight.com^
 !
 ! s2078548478.hs.eloqua.com disguised trackers
 !
-||join.pharmapackeurope.com^
 !
 ! s341504499.hs.eloqua.com disguised trackers
 !
-||kampanjat.atea.fi^
 !
 ! s1654.hs.eloqua.com disguised trackers
 !
-||know.wolterskluwerlr.com^
-||trackinglrus.wolterskluwer.com^
 !
 ! s839411425.hs.eloqua.com disguised trackers
 !
-||lakerspreferences.gleague.nba.com^
-||preferences.la-lakers.com^
 !
 ! s1364398973.hs.eloqua.com disguised trackers
 !
-||landing-effacts.wolterskluwer.com^
-||landing-kleos.wolterskluwer.com^
-||landing-smartdocument.wolterskluwer.com^
-||lrbelgium.wolterskluwer.com^
-||lrnetherlands.wolterskluwer.com^
-||lrpoland.wolterskluwer.com^
-||lrportugal.wolterskluwer.com^
-||stat.lex.pl^
-||stat.prawo.pl^
-||stat.profinfo.pl^
-||stat.wki.it^
-||stat.wolterskluwer.com^
-||stat.wolterskluwer.pl^
 !
 ! s508159127.hs.eloqua.com disguised trackers
 !
-||landing.computershare.com^
 !
 ! s3049749.hs.eloqua.com disguised trackers
 !
-||lantern.fortinet.com^
 !
 ! s570777387.hs.eloqua.com disguised trackers
 !
-||latam.thomsonreuters.com^
 !
 ! s1433593509.hs.eloqua.com disguised trackers
 !
-||learn.armaninollp.com^
 !
 ! s1133169544.hs.eloqua.com disguised trackers
 !
-||learn.carlingtech.com^
 !
 ! s1025.hs.eloqua.com disguised trackers
 !
-||learn.relationshipone.com^
 !
 ! s2417.hs.eloqua.com disguised trackers
 !
-||lfn.lfg.com^
 !
 ! s742824262.hs.eloqua.com disguised trackers
 !
-||live.alljobs.co.il^
 !
 ! s4558456.hs.eloqua.com disguised trackers
 !
-||lkr-trk.reply.com^
 !
 ! s804982657.hs.eloqua.com disguised trackers
 !
-||logistics.dbschenker.com^
-||news.dbschenker.com^
 !
 ! s1829601.hs.eloqua.com disguised trackers
 !
-||lp-eq.mitsuichemicals.com^
 !
 ! s1469681.hs.eloqua.com disguised trackers
 !
-||lp.connectedcare.wkhs.com^
 !
 ! s608.hs.eloqua.com disguised trackers
 !
-||lp.embarcadero.com^
 !
 ! s857737.hs.eloqua.com disguised trackers
 !
-||lp.info.jeffersonhealth.org^
 !
 ! s1777052651.hs.eloqua.com disguised trackers
 !
-||lp.sophos.com^
 !
 ! s1361878872.hs.eloqua.com disguised trackers
 !
-||lp.yamane-m.co.jp^
 !
 ! s1107114332.hs.eloqua.com disguised trackers
 !
-||lp1.dentsplysirona.com^
 !
 ! s1507378874.hs.eloqua.com disguised trackers
 !
-||m.premier.info.shutterstock.com^
 !
 ! s1145.hs.eloqua.com disguised trackers
 !
-||ma.hmhco.com^
 !
 ! s1660.hs.eloqua.com disguised trackers
 !
-||mail.dolce-gusto.cl^
-||mail.dolce-gusto.gr^
-||mail.dolce-gusto.pt^
-||mail.dolce-gusto.ro^
 !
 ! s748859613.hs.eloqua.com disguised trackers
 !
-||making-future.afry.com^
-||t.afry.com^
 !
 ! s1284661142.hs.eloqua.com disguised trackers
 !
-||map.rockwellautomation.com^
 !
 ! s55867.hs.eloqua.com disguised trackers
 !
-||marketing.championhomes.com^
 !
 ! s1629121027.hs.eloqua.com disguised trackers
 !
-||marketing.royalalaskanmovers.com^
 !
 ! s1023994345.hs.eloqua.com disguised trackers
 !
-||markets.eclerx.com^
-||services.eclerx.com^
 !
 ! s640556.hs.eloqua.com disguised trackers
 !
-||mat.lgdisplay.com^
 !
 ! s223222610.hs.eloqua.com disguised trackers
 !
-||medion.interamerican.gr^
 !
 ! s341921710.hs.eloqua.com disguised trackers
 !
-||memelq.acs.org^
 !
 ! s2894949.hs.eloqua.com disguised trackers
 !
-||metrics.mhi.com^
 !
 ! s2126871889.hs.eloqua.com disguised trackers
 !
-||metricsinfo.edc.ca^
-||secureinfo.edc.ca^
 !
 ! s893956921.hs.eloqua.com disguised trackers
 !
-||mfg.informabi.com^
 !
 ! s50277215.hs.eloqua.com disguised trackers
 !
-||mkt-tracking.cloudmargin.com^
 !
 ! s205422009.hs.eloqua.com disguised trackers
 !
-||mkt.compactaprint.com.br^
 !
 ! s417558342.hs.eloqua.com disguised trackers
 !
-||my.orhp.com^
 !
 ! s1475040089.hs.eloqua.com disguised trackers
 !
-||myevents.thalesgroup.com^
-||myfeed.thalesgroup.com^
-||t.thalesgroup.com^
 !
 ! s736472.hs.eloqua.com disguised trackers
 !
-||myfuture.futureelectronics.com^
 !
 ! s43975733.hs.eloqua.com disguised trackers
 !
-||nbg.seagate.com^
 !
 ! s1816717515.hs.eloqua.com disguised trackers
 !
-||news.communications-rmngp.fr^
 !
 ! s645654258.hs.eloqua.com disguised trackers
 !
-||newsletters.bancsabadell.com^
 !
 ! s23693100.hs.eloqua.com disguised trackers
 !
-||nordics.atradius.com^
 !
 ! s1758221812.hs.eloqua.com disguised trackers
 !
-||now.greenbuildexpo.com^
 !
 ! s244475.hs.eloqua.com disguised trackers
 !
-||oci.dyn.com^
 !
 ! s20103530.hs.eloqua.com disguised trackers
 !
-||offers.la-z-boy.com^
 !
 ! s279295639.hs.eloqua.com disguised trackers
 !
-||oiat.dow.com^
 !
 ! s1445544.hs.eloqua.com disguised trackers
 !
-||page.health.tmcaz.com^
-||tracking.health.tmcaz.com^
 !
 ! s103126886.hs.eloqua.com disguised trackers
 !
-||pages.canon.com.au^
 !
 ! s1909208.hs.eloqua.com disguised trackers
 !
-||pages.ledger.com^
 !
 ! s383344069.hs.eloqua.com disguised trackers
 !
-||pages.pharmaintelligence.informa.com^
 !
 ! s9445901.hs.eloqua.com disguised trackers
 !
-||pages.response.terex.com^
-||tracking.response.terex.com^
 !
 ! s6148858.hs.eloqua.com disguised trackers
 !
-||pages.sailgp.com^
-||tracking.sailgp.com^
 !
 ! s1625795586.hs.eloqua.com disguised trackers
 !
-||pages.visitdubai.com^
-||tracking.visitdubai.com^
 !
 ! s983166544.hs.eloqua.com disguised trackers
 !
-||partnersuccessmetrics.cisco.com^
 !
 ! s1887739738.hs.eloqua.com disguised trackers
 !
-||pcm.symantec.com^
 !
 ! s46849916.hs.eloqua.com disguised trackers
 !
-||pgs.farmprogress.com^
-||trk.beefmagazine.com^
-||trk.farmprogress.com^
-||trk.nationalhogfarmer.com^
 !
 ! s1734025471.hs.eloqua.com disguised trackers
 !
-||plbusiness.samsung.com^
-||tracking.europe.business.samsung.com^
 !
 ! s1634886871.hs.eloqua.com disguised trackers
 !
-||posgrado.javeriana.edu.co^
-||pregrados.javeriana.edu.co^
 !
 ! s1632284857.hs.eloqua.com disguised trackers
 !
-||pr.cision.com^
-||pr.prnewswire.com^
 !
 ! s1630091360.hs.eloqua.com disguised trackers
 !
-||profiling.outokumpu.com^
 !
 ! s2044960264.hs.eloqua.com disguised trackers
 !
-||profiling.ruukki.com^
 !
 ! s1892927.hs.eloqua.com disguised trackers
 !
-||promotion.lginnotek.com^
 !
 ! s59104477.hs.eloqua.com disguised trackers
 !
-||promotion.sedo.com^
 !
 ! s1913652004.hs.eloqua.com disguised trackers
 !
-||pubstr.acs.org^
-||pubstr.chemrxiv.org^
 !
 ! s1450716703.hs.eloqua.com disguised trackers
 !
-||rc.precisely.com^
-||tracking.precisely.com^
 !
 ! s1233.hs.eloqua.com disguised trackers
 !
-||redwingforbusiness.redwingsafety.com^
 !
 ! s2150.hs.eloqua.com disguised trackers
 !
-||reg.informationweek.com^
-||trk.darkreading.com^
-||trk.enterpriseconnect.com^
-||trk.gamedeveloper.com^
-||trk.gdconf.com^
-||trk.informatech.com^
-||trk.informationweek.com^
-||trk.networkcomputing.com^
 !
 ! s459.hs.eloqua.com disguised trackers
 !
-||resources.opentext.com^
-||resources.opentext.fr^
 !
 ! s779983035.hs.eloqua.com disguised trackers
 !
-||response.arizonacoyotes.com^
 !
 ! p02j.hs.eloqua.com disguised trackers
 !
@@ -16567,99 +14738,60 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s2006753802.hs.eloqua.com disguised trackers
 !
-||response.desjardins.com^
 !
 ! s225884627.hs.eloqua.com disguised trackers
 !
-||response.emoneyadvisor.com^
-||tracking.emoneyadvisor.com^
 !
 ! s893759278.hs.eloqua.com disguised trackers
 !
-||response.iqpc.com^
 !
 ! s1042585190.hs.eloqua.com disguised trackers
 !
-||response.playpower.com^
-||response.usa-shade.com^
 !
 ! s1528.hs.eloqua.com disguised trackers
 !
-||response.splunk.com^
 !
 ! s2116941023.hs.eloqua.com disguised trackers
 !
-||s.sick.com^
 !
 ! s362693299.hs.eloqua.com disguised trackers
 !
-||s362693299.aon.com^
 !
 ! s976772240.hs.eloqua.com disguised trackers
 !
-||satracking.finning.com^
 !
 ! s159500889.hs.eloqua.com disguised trackers
 !
-||secure-eugo.arrow.com^
 !
 ! s3086.hs.eloqua.com disguised trackers
 !
-||secure.immixgroup.com^
 !
 ! s2427.hs.eloqua.com disguised trackers
 !
-||secure.info.domo.com^
 !
 ! s380021914.hs.eloqua.com disguised trackers
 !
-||secure.medtronicinteract.com^
 !
 ! s1744479642.hs.eloqua.com disguised trackers
 !
-||secure.mycalcas.com^
 !
 ! s3805888.hs.eloqua.com disguised trackers
 !
-||secure.sw.broadcom.com^
 !
 ! s1133198723.hs.eloqua.com disguised trackers
 !
-||secure.wiley.com^
 !
 ! s1368768478.hs.eloqua.com disguised trackers
 !
-||securecookies.dustin.dk^
-||securecookies.dustin.fi^
-||securecookies.dustin.nl^
-||securecookies.dustin.no^
-||securecookies.dustin.se^
-||securecookies.dustinhome.dk^
-||securecookies.dustinhome.fi^
-||securecookies.dustinhome.nl^
-||securecookies.dustinhome.no^
-||securecookies.dustinhome.se^
 !
 ! s1423675.hs.eloqua.com disguised trackers
 !
-||securecookiesdustininfo.dustin.dk^
-||securecookiesdustininfo.dustin.fi^
-||securecookiesdustininfo.dustin.nl^
-||securecookiesdustininfo.dustin.no^
-||securecookiesdustininfo.dustin.se^
-||securecookiesdustininfo.dustinhome.dk^
-||securecookiesdustininfo.dustinhome.fi^
-||securecookiesdustininfo.dustinhome.nl^
-||securecookiesdustininfo.dustinhome.no^
-||securecookiesdustininfo.dustinhome.se^
 !
 ! s1782160512.hs.eloqua.com disguised trackers
 !
-||secured.online.avon.com^
 !
 ! s2437.hs.eloqua.com disguised trackers
 !
-||secureforms.nrs-inc.com^
 !
 ! s2085091463.hs.eloqua.com disguised trackers
 !
@@ -16667,15 +14799,12 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s2824.hs.eloqua.com disguised trackers
 !
-||secureforms.xperthr.com^
 !
 ! s1505435838.hs.eloqua.com disguised trackers
 !
-||secureforms.xperthr.nl^
 !
 ! s146977739.hs.eloqua.com disguised trackers
 !
-||securetracking.golfpride.com^
 !
 ! s1236249806.hs.eloqua.com disguised trackers
 !
@@ -16691,24 +14820,18 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s394336720.hs.eloqua.com disguised trackers
 !
-||site.connect.mydrreddys.com^
-||tracking.drreddys.com^
 !
 ! s1447373.hs.eloqua.com disguised trackers
 !
-||site.infosysbpm.com^
 !
 ! s849425.hs.eloqua.com disguised trackers
 !
-||situationalintelligence.cognyte.com^
 !
 ! s1164411065.hs.eloqua.com disguised trackers
 !
-||smtps.carte-gr.total.fr^
 !
 ! s409256115.hs.eloqua.com disguised trackers
 !
-||solutions.covance.com^
 !
 ! s530566577.hs.eloqua.com disguised trackers
 !
@@ -16718,7 +14841,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s456196690.hs.eloqua.com disguised trackers
 !
-||spaces.martela.com^
 !
 ! s244630019.hs.eloqua.com disguised trackers
 !
@@ -16728,270 +14850,198 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1435678.hs.eloqua.com disguised trackers
 !
-||stat.liaisons-sociales.fr^
 !
 ! s1896673673.hs.eloqua.com disguised trackers
 !
-||stat.starterre.fr^
 !
 ! s1728163616.hs.eloqua.com disguised trackers
 !
-||strikenurse.usnursing.com^
 !
 ! s861531437.hs.eloqua.com disguised trackers
 !
-||subscribe.dnvgl.com^
-||webinar.dnvgl.com^
 !
 ! s2950557.hs.eloqua.com disguised trackers
 !
-||support.labcorp.com^
 !
 ! s1460333.hs.eloqua.com disguised trackers
 !
-||t.12thman.com^
 !
 ! s1181141.hs.eloqua.com disguised trackers
 !
-||t.arizonawildcats.com^
 !
 ! s2767058.hs.eloqua.com disguised trackers
 !
-||t.arkansasrazorbacks.com^
 !
 ! s4647128.hs.eloqua.com disguised trackers
 !
-||t.auburntigers.com^
 !
 ! s3978542.hs.eloqua.com disguised trackers
 !
-||t.bceagles.com^
 !
 ! s2177364.hs.eloqua.com disguised trackers
 !
-||t.bucky.uwbadgers.com^
 !
 ! s2906346.hs.eloqua.com disguised trackers
 !
-||t.budweisergardens.com^
 !
 ! s718390.hs.eloqua.com disguised trackers
 !
-||t.calbears.com^
 !
 ! s4041393.hs.eloqua.com disguised trackers
 !
-||t.cincinnatiarts.org^
 !
 ! s1674425.hs.eloqua.com disguised trackers
 !
-||t.cubuffs.com^
 !
 ! s2336561.hs.eloqua.com disguised trackers
 !
-||t.dawsoncreekeventscentre.com^
 !
 ! s2941439.hs.eloqua.com disguised trackers
 !
-||t.ecupirates.com^
 !
 ! s3953753.hs.eloqua.com disguised trackers
 !
-||t.fairparkdallas.com^
 !
 ! s5797642.hs.eloqua.com disguised trackers
 !
-||t.festo.com^
 !
 ! s70543.hs.eloqua.com disguised trackers
 !
-||t.foxtheatre.org^
 !
 ! s77283.hs.eloqua.com disguised trackers
 !
-||t.friars.com^
 !
 ! s717488.hs.eloqua.com disguised trackers
 !
-||t.goarmywestpoint.com^
 !
 ! s2394888.hs.eloqua.com disguised trackers
 !
-||t.gobearcats.com^
 !
 ! s662344.hs.eloqua.com disguised trackers
 !
-||t.gofrogs.com^
 !
 ! s4743215.hs.eloqua.com disguised trackers
 !
-||t.gojacks.com^
 !
 ! s1173582.hs.eloqua.com disguised trackers
 !
-||t.gomocs.com^
 !
 ! s2414213.hs.eloqua.com disguised trackers
 !
-||t.gophersports.com^
 !
 ! s261098.hs.eloqua.com disguised trackers
 !
-||t.gostanford.com^
 !
 ! s1601981.hs.eloqua.com disguised trackers
 !
-||t.goxavier.com^
 !
 ! s1108752.hs.eloqua.com disguised trackers
 !
-||t.hawkeyesports.com^
 !
 ! s20342.hs.eloqua.com disguised trackers
 !
-||t.huskers.com^
 !
 ! s2334089.hs.eloqua.com disguised trackers
 !
-||t.jmusports.com^
 !
 ! s33828.hs.eloqua.com disguised trackers
 !
-||t.krannertcenter.com^
 !
 ! s22009.hs.eloqua.com disguised trackers
 !
-||t.kstatesports.com^
 !
 ! s2342053.hs.eloqua.com disguised trackers
 !
-||t.libertyfirstcreditunionarena.com^
 !
 ! s533626.hs.eloqua.com disguised trackers
 !
-||t.lsusports.net^
 !
 ! s773600.hs.eloqua.com disguised trackers
 !
-||t.msuspartans.com^
 !
 ! s2234957.hs.eloqua.com disguised trackers
 !
-||t.navysports.com^
 !
 ! s370925.hs.eloqua.com disguised trackers
 !
-||t.ohiobobcats.com^
 !
 ! s2200554.hs.eloqua.com disguised trackers
 !
-||t.okstate.com^
 !
 ! s2586496.hs.eloqua.com disguised trackers
 !
-||t.olemisssports.com^
 !
 ! s5520421.hs.eloqua.com disguised trackers
 !
-||t.pittsburghpanthers.com^
 !
 ! s3192205.hs.eloqua.com disguised trackers
 !
-||t.playhousesquare.org^
 !
 ! s7610.hs.eloqua.com disguised trackers
 !
-||t.poconoraceway.com^
 !
 ! s2279082.hs.eloqua.com disguised trackers
 !
-||t.pplcenter.com^
 !
 ! s2661780.hs.eloqua.com disguised trackers
 !
-||t.ramblinwreck.com^
 !
 ! s3921539.hs.eloqua.com disguised trackers
 !
-||t.seminoles.com^
 !
 ! s873312.hs.eloqua.com disguised trackers
 !
-||t.sjsuspartans.com^
 !
 ! s3327771.hs.eloqua.com disguised trackers
 !
-||t.soonersports.com^
 !
 ! s4239565.hs.eloqua.com disguised trackers
 !
-||t.texassports.com^
 !
 ! s9011856.hs.eloqua.com disguised trackers
 !
-||t.texastech.com^
 !
 ! s5183409.hs.eloqua.com disguised trackers
 !
-||t.ticketstaronline.com^
 !
 ! s2425245.hs.eloqua.com disguised trackers
 !
-||t.uclabruins.com^
 !
 ! s2019595.hs.eloqua.com disguised trackers
 !
-||t.umassathletics.com^
 !
 ! s593281.hs.eloqua.com disguised trackers
 !
-||t.umterps.com^
 !
 ! s474024.hs.eloqua.com disguised trackers
 !
-||t.und.com^
 !
 ! s5531012.hs.eloqua.com disguised trackers
 !
-||t.unlvrebels.com^
 !
 ! s215943.hs.eloqua.com disguised trackers
 !
-||t.villanova.com^
 !
 ! s1013753.hs.eloqua.com disguised trackers
 !
-||t.vucommodores.com^
 !
 ! s790935.hs.eloqua.com disguised trackers
 !
-||t.whartoncenter.com^
 !
 ! s2590381.hs.eloqua.com disguised trackers
 !
-||t.wvusports.com^
 !
 ! s301200.hs.eloqua.com disguised trackers
 !
-||t.xtreamarena.com^
 !
 ! s706700.hs.eloqua.com disguised trackers
 !
-||tablo.outsetmedical.com^
 !
 ! s297511345.hs.eloqua.com disguised trackers
 !
-||talenteq.intuit.com^
 !
 ! s1885539667.hs.eloqua.com disguised trackers
 !
-||technology.informaengage.com^
-||trk.afcom.com^
-||trk.channelfutures.com^
-||trk.datacenterknowledge.com^
-||trk.iotworldtoday.com^
-||trk.itprotoday.com^
-||trk.webhostingtalk.com^
 !
 ! s1836379484.hs.eloqua.com disguised trackers
 !
@@ -16999,7 +15049,6 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s3016511.hs.eloqua.com disguised trackers
 !
-||ticketoffice.liberty.edu^
 !
 ! s711385017.hs.eloqua.com disguised trackers
 !
@@ -17009,80 +15058,45 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s19803528.hs.eloqua.com disguised trackers
 !
-||trace.insead.edu^
-||tracking.insead.edu^
 !
 ! s1968580696.hs.eloqua.com disguised trackers
 !
-||track-e.cypress.com^
-||track-e.infineon.com^
 !
 ! s2021.hs.eloqua.com disguised trackers
 !
-||track.abrdn.com^
-||track.financialfairness.org.uk^
 !
 ! s810866859.hs.eloqua.com disguised trackers
 !
-||track.auckland.ac.nz^
 !
 ! s2033696.hs.eloqua.com disguised trackers
 !
-||track.clubcar.com^
 !
 ! s694841291.hs.eloqua.com disguised trackers
 !
-||track.connectwise.com^
 !
 ! s566810826.hs.eloqua.com disguised trackers
 !
-||track.docusign.co.uk^
-||track.docusign.com^
-||track.docusign.com.br^
-||track.docusign.com.es^
-||track.docusign.de^
-||track.docusign.fr^
-||track.docusign.jp^
-||track.docusign.mx^
 !
 ! s1990924103.hs.eloqua.com disguised trackers
 !
-||track.ferrari.com^
-||track.ferraridealers.com^
 !
 ! s2255121.hs.eloqua.com disguised trackers
 !
-||track.info.cancertherapyadvisor.com^
-||track.info.clinicaladvisor.com^
-||track.info.dermatologyadvisor.com^
-||track.info.empr.com^
-||track.info.gastroenterologyadvisor.com^
-||track.info.infectiousdiseaseadvisor.com^
-||track.info.neurologyadvisor.com^
-||track.info.oncologynurseadvisor.com^
-||track.info.ophthalmologyadvisor.com^
-||track.info.optometryadvisor.com^
-||track.info.rheumatologyadvisor.com^
 !
 ! s305496.hs.eloqua.com disguised trackers
 !
-||track.info.mcknights.com^
-||track.info.mcknightsseniorliving.com^
 !
 ! s2175572.hs.eloqua.com disguised trackers
 !
-||track.info.mmm-online.com^
 !
 ! s3096123.hs.eloqua.com disguised trackers
 !
 !
 ! s375943868.hs.eloqua.com disguised trackers
 !
-||track.inspirage.com^
 !
 ! s19745433.hs.eloqua.com disguised trackers
 !
-||track.lesmills.com^
 !
 ! s1990706537.hs.eloqua.com disguised trackers
 !
@@ -17092,40 +15106,30 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s45830372.hs.eloqua.com disguised trackers
 !
-||tracking-explore-uat.agilent.com^
 !
 ! s1931362753.hs.eloqua.com disguised trackers
 !
-||tracking-sandbox.vodafone.co.uk^
 !
 ! s459453599.hs.eloqua.com disguised trackers
 !
 !
 ! s414407.hs.eloqua.com disguised trackers
 !
-||tracking.adtran.com^
 !
 ! s688533.hs.eloqua.com disguised trackers
 !
-||tracking.agora.io^
 !
 ! s882904488.hs.eloqua.com disguised trackers
 !
-||tracking.aifsabroad.com^
-||tracking.myaupairinamerica.com^
 !
 ! s365128.hs.eloqua.com disguised trackers
 !
-||tracking.idwholesaler.com^
 !
 ! s1887074206.hs.eloqua.com disguised trackers
 !
-||tracking.americas.business.samsung.com^
 !
 ! s868446402.hs.eloqua.com disguised trackers
 !
-||tracking.analysis.hibu.com^
-||tracking.hibu.com^
 !
 ! s1734073713.hs.eloqua.com disguised trackers
 !
@@ -17135,75 +15139,57 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1006266832.hs.eloqua.com disguised trackers
 !
-||tracking.bnppre.fr^
 !
 ! s1571500494.hs.eloqua.com disguised trackers
 !
-||tracking.bonava.ru^
 !
 ! s2132.hs.eloqua.com disguised trackers
 !
-||tracking.bradyid.com^
 !
 ! s1887277791.hs.eloqua.com disguised trackers
 !
-||tracking.business.comcast.com^
 !
 ! s1253383126.hs.eloqua.com disguised trackers
 !
-||tracking.businessdirect.bt.com^
 !
 ! s743081401.hs.eloqua.com disguised trackers
 !
-||tracking.bv.com^
 !
 ! s2138.hs.eloqua.com disguised trackers
 !
-||tracking.cengage.com^
 !
 ! s1647363395.hs.eloqua.com disguised trackers
 !
-||tracking.changehealthcare.com^
 !
 ! s856856423.hs.eloqua.com disguised trackers
 !
-||tracking.columbiabank.com^
 !
 ! s6137615.hs.eloqua.com disguised trackers
 !
-||tracking.connect.nicklaushealth.org^
 !
 ! s252818013.hs.eloqua.com disguised trackers
 !
-||tracking.cranepi.com^
 !
 ! s1358.hs.eloqua.com disguised trackers
 !
-||tracking.direxion.com^
 !
 ! s879985536.hs.eloqua.com disguised trackers
 !
-||tracking.dr-10.com^
 !
 ! s1712683840.hs.eloqua.com disguised trackers
 !
-||tracking.drivercenter.eu^
 !
 ! s534595109.hs.eloqua.com disguised trackers
 !
-||tracking.edb.gov.sg^
 !
 ! s1672222.hs.eloqua.com disguised trackers
 !
-||tracking.eloq.soa.org^
 !
 ! s97329354.hs.eloqua.com disguised trackers
 !
-||tracking.eloqua.modernize.com^
 !
 ! s1739717246.hs.eloqua.com disguised trackers
 !
-||tracking.evergy.com^
 !
 ! s275197016.hs.eloqua.com disguised trackers
 !
@@ -17211,242 +15197,174 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1791.hs.eloqua.com disguised trackers
 !
-||tracking.flukecal.com^
 !
 ! s2064197708.hs.eloqua.com disguised trackers
 !
-||tracking.fticonsulting.com^
 !
 ! s544.hs.eloqua.com disguised trackers
 !
-||tracking.ftitechnology.com^
 !
 ! s8258.hs.eloqua.com disguised trackers
 !
-||tracking.global-demand02.nec.com^
 !
 ! s192083571.hs.eloqua.com disguised trackers
 !
-||tracking.go.mge.com^
 !
 ! s1069047711.hs.eloqua.com disguised trackers
 !
-||tracking.go.onshape.com^
 !
 ! s8896332.hs.eloqua.com disguised trackers
 !
-||tracking.go.toyobo.co.jp^
 !
 ! s1253878073.hs.eloqua.com disguised trackers
 !
-||tracking.hcltech.com^
 !
 ! s1022.hs.eloqua.com disguised trackers
 !
-||tracking.igloosoftware.com^
 !
 ! s1800677.hs.eloqua.com disguised trackers
 !
-||tracking.info.ivanti.com^
 !
 ! s956780691.hs.eloqua.com disguised trackers
 !
-||tracking.info.rcgt.com^
 !
 ! s1733242902.hs.eloqua.com disguised trackers
 !
-||tracking.info.sailpoint.com^
 !
 ! s1133.hs.eloqua.com disguised trackers
 !
-||tracking.info.servicenow.com^
 !
 ! s998125501.hs.eloqua.com disguised trackers
 !
-||tracking.insperity.com^
 !
 ! s869025237.hs.eloqua.com disguised trackers
 !
-||tracking.laurelsprings.com^
 !
 ! s61956.hs.eloqua.com disguised trackers
 !
-||tracking.learn.oakstreethealth.com^
 !
 ! s1717.hs.eloqua.com disguised trackers
 !
-||tracking.lenovo.com^
 !
 ! s1407994545.hs.eloqua.com disguised trackers
 !
-||tracking.lincolnfinancialgroup.lfg.com^
 !
 ! s732646936.hs.eloqua.com disguised trackers
 !
-||tracking.liwest.at^
 !
 ! s881106.hs.eloqua.com disguised trackers
 !
-||tracking.mail.ti.com^
-||tracking.mail.ti.com.cn^
 !
 ! s1011041821.hs.eloqua.com disguised trackers
 !
-||tracking.max.co.il^
 !
 ! s73756918.hs.eloqua.com disguised trackers
 !
-||tracking.mkt-email.samsungsds.com^
 !
 ! s908331520.hs.eloqua.com disguised trackers
 !
-||tracking.mwe.com^
 !
 ! s188399297.hs.eloqua.com disguised trackers
 !
-||tracking.myregus.com^
-||tracking.regus.com^
 !
 ! s1981692173.hs.eloqua.com disguised trackers
 !
-||tracking.nasdaq.com^
 !
 ! s2071357376.hs.eloqua.com disguised trackers
 !
-||tracking.nissan-dubai.com^
 !
 ! s19892481.hs.eloqua.com disguised trackers
 !
-||tracking.oldnational.com^
 !
 ! s1427524768.hs.eloqua.com disguised trackers
 !
-||tracking.online.wisc.edu^
-||tracking.pdc.wisc.edu^
-||tracking.precollege.wisc.edu^
-||tracking.summer.wisc.edu^
 !
 ! s5020318.hs.eloqua.com disguised trackers
 !
-||tracking.opentable.com^
 !
 ! s242670.hs.eloqua.com disguised trackers
 !
-||tracking.oppd.com^
 !
 ! s1920192983.hs.eloqua.com disguised trackers
 !
-||tracking.pella.com^
 !
 ! s459912.hs.eloqua.com disguised trackers
 !
-||tracking.pennmedicine.princetonhcs.org^
 !
 ! s1953885032.hs.eloqua.com disguised trackers
 !
-||tracking.pepsicopartners.com^
 !
 ! s2020524045.hs.eloqua.com disguised trackers
 !
-||tracking.petrelocation.com^
 !
 ! s459519.hs.eloqua.com disguised trackers
 !
-||tracking.protective.com^
 !
 ! s1505979.hs.eloqua.com disguised trackers
 !
-||tracking.reply.broadwayinhollywood.com^
-||tracking.reply.dpacnc.com^
 !
 ! s1392407584.hs.eloqua.com disguised trackers
 !
-||tracking.schneider.com^
 !
 ! s839047.hs.eloqua.com disguised trackers
 !
-||tracking.seakeeper.com^
 !
 ! s576132794.hs.eloqua.com disguised trackers
 !
-||tracking.service.cz.nl^
-||www.service.cz.nl^
 !
 ! s1799992300.hs.eloqua.com disguised trackers
 !
-||tracking.sierrawireless.com^
 !
 ! s1387486446.hs.eloqua.com disguised trackers
 !
-||tracking.singlestore.com^
 !
 ! s499344317.hs.eloqua.com disguised trackers
 !
-||tracking.smartbets.com^
-||tracking.wettfreunde.net^
 !
 ! s1832.hs.eloqua.com disguised trackers
 !
-||tracking.stemcell.com^
 !
 ! s1819762567.hs.eloqua.com disguised trackers
 !
-||tracking.tdk.com^
 !
 ! s441910513.hs.eloqua.com disguised trackers
 !
-||tracking.ti.com^
-||tracking.ti.com.cn^
 !
 ! s1487871083.hs.eloqua.com disguised trackers
 !
-||tracking.trinet.com^
 !
 ! s860818199.hs.eloqua.com disguised trackers
 !
-||tracking.umbrella.com^
 !
 ! s1207496928.hs.eloqua.com disguised trackers
 !
-||tracking.unisabana.edu.co^
 !
 ! s1046939679.hs.eloqua.com disguised trackers
 !
-||tracking.usj.es^
 !
 ! s1120.hs.eloqua.com disguised trackers
 !
-||tracking.verisk.com^
-||w3.air-worldwide.com^
 !
 ! s1389013426.hs.eloqua.com disguised trackers
 !
-||tracking.veritas.com^
 !
 ! s157200592.hs.eloqua.com disguised trackers
 !
-||tracking.vertiv.com^
-||tracking.vertivco.com^
 !
 ! s1125168648.hs.eloqua.com disguised trackers
 !
-||tracking.virtus.com^
 !
 ! s345548666.hs.eloqua.com disguised trackers
 !
-||tracking1.tena.com^
 !
 ! s1472843.hs.eloqua.com disguised trackers
 !
-||tracking2.labcorp.com^
 !
 ! s1234457786.hs.eloqua.com disguised trackers
 !
-||trackingcareers.accenture.com^
 !
 ! s1122776361.hs.eloqua.com disguised trackers
 !
-||trackingmms.accenture.com^
 !
 ! s14611781.hs.eloqua.com disguised trackers
 !
@@ -17454,118 +15372,75 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s171237132.hs.eloqua.com disguised trackers
 !
-||tracks3.ferrari.com^
 !
 ! s468913550.hs.eloqua.com disguised trackers
 !
-||trials.questdiagnostics.com^
 !
 ! s966913078.hs.eloqua.com disguised trackers
 !
-||trk.acukwik.com^
-||trk.aircharterguide.com^
-||trk.aviationweek.com^
-||trk.routesonline.com^
 !
 ! s949606000.hs.eloqua.com disguised trackers
 !
 ||trk.admmontreal.com^
 ||trk.admtoronto.com^
-||trk.designnews.com^
-||trk.mddionline.com^
-||trk.packagingdigest.com^
-||trk.plasticstoday.com^
-||trk.powderandbulksolids.com^
-||trk.thebatteryshow.eu^
-||trkime.informa.com^
 !
 ! s230127911.hs.eloqua.com disguised trackers
 !
-||trk.advisory.com^
 !
 ! s1587191664.hs.eloqua.com disguised trackers
 !
 ||trk.americancityandcounty.com^
-||trk.iwceexpo.com^
 !
 ! s930.hs.eloqua.com disguised trackers
 !
-||trk.business.westernunion.co.uk^
-||trk.business.westernunion.com^
-||trk.convera.com^
-||trk.en-cz.business.westernunion.com^
-||trk.en.business.westernunion.ch^
-||trk.fr.business.westernunion.ch^
 !
 ! s1252280979.hs.eloqua.com disguised trackers
 !
-||trk.contentmarketinginstitute.com^
 !
 ! s1346786309.hs.eloqua.com disguised trackers
 !
-||trk.fintechfutures.com^
-||trk.wealthmanagement.com^
 !
 ! s1943367007.hs.eloqua.com disguised trackers
 !
-||trk.food-management.com^
-||trk.nrn.com^
-||trk.restaurant-hospitality.com^
-||trk.supermarketnews.com^
 !
 ! s1931078500.hs.eloqua.com disguised trackers
 !
-||trk.magicfashionevents.com^
 !
 ! s736811171.hs.eloqua.com disguised trackers
 !
-||trk.meetingsnet.com^
 !
 ! s668595.hs.eloqua.com disguised trackers
 !
-||trk.metronet.com^
-||trk.metronetbusiness.com^
 !
 ! s1893331.hs.eloqua.com disguised trackers
 !
-||trk.mktg.nec.com^
 !
 ! s434533438.hs.eloqua.com disguised trackers
 !
-||trk.wardsauto.com^
 !
 ! s381216.hs.eloqua.com disguised trackers
 !
-||trk01.iotworldtoday.com^
 !
 ! s2677.hs.eloqua.com disguised trackers
 !
-||updates.gaylordhotels.com^
 !
 ! s2073603363.hs.eloqua.com disguised trackers
 !
-||us.ricoh-usa.com^
 !
 ! s1824193043.hs.eloqua.com disguised trackers
 !
-||visit.donateblood.com.au^
-||visit.lifeblood.com.au^
 !
 ! s2307.hs.eloqua.com disguised trackers
 !
-||visit.hypertherm.com^
 !
 ! s2022633471.hs.eloqua.com disguised trackers
 !
-||visit.tafensw.edu.au^
 !
 ! s434397.hs.eloqua.com disguised trackers
 !
-||web.care.eehealth.org^
 !
 ! s4758959.hs.eloqua.com disguised trackers
 !
-||web.care.mhs.net^
 !
 ! s2698233.hs.eloqua.com disguised trackers
 !
@@ -17573,83 +15448,63 @@ charlestownwyllie.oaklawnnonantum.com^
 !
 ! s1595272163.hs.eloqua.com disguised trackers
 !
-||web.care.sheppardpratt.org^
 !
 ! s124923.hs.eloqua.com disguised trackers
 !
-||web.care.wakemed.org^
 !
 ! s2287589.hs.eloqua.com disguised trackers
 !
-||web.health.childrenswi.org^
 !
 ! s984275552.hs.eloqua.com disguised trackers
 !
-||web.health.memorialcare.org^
 !
 ! s5267799.hs.eloqua.com disguised trackers
 !
-||web.houstontexans.com^
 !
 ! s220745253.hs.eloqua.com disguised trackers
 !
-||web.northwestern.nm.org^
 !
 ! s393074.hs.eloqua.com disguised trackers
 !
-||web.wearejust.co.uk^
 !
 ! s1711294798.hs.eloqua.com disguised trackers
 !
-||webtracking.aucmed.edu^
 !
 ! s1683655354.hs.eloqua.com disguised trackers
 !
-||webtracking.becker.com^
 !
 ! s125869073.hs.eloqua.com disguised trackers
 !
-||webtracking.chamberlain.edu^
 !
 ! s1349436993.hs.eloqua.com disguised trackers
 !
-||webtracking.medical.rossu.edu^
 !
 ! s301572493.hs.eloqua.com disguised trackers
 !
-||webtracking.oncourselearning.com^
 !
 ! s1173830714.hs.eloqua.com disguised trackers
 !
-||welcome.item24.cz^
 !
 ! s418793455.hs.eloqua.com disguised trackers
 !
-||www.dheerajrealitydemo.com^
 !
 ! s218036981.hs.eloqua.com disguised trackers
 !
-||www.eventos-ins.com^
 !
 ! s1894139733.hs.eloqua.com disguised trackers
 !
-||www.learn.dunnhumby.com^
 !
 ! s2090047988.hs.eloqua.com disguised trackers
 !
-||www.mkt.uvg.edu.gt^
 !
 ! s1606748220.hs.eloqua.com disguised trackers
 !
-||www.solutions.prudential.com^
 !
 ! s84397462.hs.eloqua.com disguised trackers
 !
-||www.zakelijk.cz.nl^
 !
 ! s1755874914.hs.eloqua.com disguised trackers
 !
-||yourporsche.nabooda-auto.com^
 !
 ! Otto Group : oghub.io disguised trackers
 !
@@ -18667,22 +16522,17 @@ charlestownwyllie.oaklawnnonantum.com^
 ||wt.distrelec.com^
 !
 !
-||backup.data.srf.ch^
 ||da.hornbach.be^
 ||data.janvanderstorm.de^
 ||data.vdi-wissensforum.de^
 ||di.ifolor.dk^
 ||di.ifolor.it^
-||foro.data.srf.ch^
 ||img.foodspring.at^
 ||img.foodspring.de^
 ||img.foodspring.fr^
 ||img.foodspring.it^
-||lax.data.srf.ch^
 ||mit.bhw.de^
-||nov.data.srf.ch^
 ||prophet.heise-academy.de^
-||s5.data.srf.ch^
 ||text.benefitsatwork.pt^
 ||trk.krebsversicherung.de^
 ||w7.berliner-silvester.de^
@@ -18768,7 +16618,6 @@ charlestownwyllie.oaklawnnonantum.com^
 /outLoging.js
 /outLoging2.js
 /acc/acctag.js
-/js/wherego_tracker.js?
 .jp/log.php?
 .jp/static/js/track.js
 /oo/cl*.js?rd=$1p
@@ -18834,14 +16683,12 @@ charlestownwyllie.oaklawnnonantum.com^
 /track.php?
 /check.php?t=*&rand=$image,1p
 /akamai/*/mediaanalytics/Mediaanalytics.min.js
-/wp-content/plugins/pb-ga-google-analytics/*$domain=~wordpress.org
 /dooanalytics/*$script
 /w_js.php|$script,1p
 /plugins/aurora-heatmap$stylesheet,script
 /pum/*/analytics/*
 /wp-content/plugins/google-analytics-premium/*
 /js/ad_insight/*
-/.bootscripts/analytics.min.js
 /exactag_clientside.js
 /stats.php?*event=$image
 /duracelltomi-google-tag-manager/*$script
@@ -18859,7 +16706,6 @@ directtrack.*.js
 /wp-content/plugins/wp-google-analytics-events/*
 /rainbow/track
 /mip-stats-cnzz/*
-/flying-analytics/js/analytics.js
 /pixel/?block_id=*&hash=*&host=
 .demandbase.*.js
 /common/tracking/webtrekk
@@ -18883,7 +16729,6 @@ directtrack.*.js
 .hit.stat24.
 .hit.ua/hit?
 .jp/analyze/
-.jp/urchin.js
 .microsoft.*/broker.js$domain=~technet.microsoft.com
 .microsoft.com/trans_pixel.
 .microsoft.com/wupixel/
@@ -18893,7 +16738,6 @@ directtrack.*.js
 /beacon.php3?
 /beacon.php?
 /cb-pixel.gif?
-/cdn-cgi/pe/bag2?*.google-analytics.com
 /cdn-cgi/pe/bag2?*bluekai.com
 /cdn-cgi/pe/bag2?*bounceexchange.com
 /cdn-cgi/pe/bag2?*cdn.onthe.io%2Fio.js
@@ -18920,7 +16764,6 @@ directtrack.*.js
 /cdn-cgi/pe/bag2?r[]=*whos.amung.us
 /clicktrack/*
 /cp2.gif?
-/dynaTraceMonitor?
 /get_cdns?$3p,xhr
 /hit-increment/*
 /hitartirici/*
@@ -18937,8 +16780,6 @@ directtrack.*.js
 /tealeaf.config.js
 /tealeafTarget2.html
 /tns-counter.js
-/tracking.jsp^
-/tracking/tracking.js
 /visilabs.min.js
 /webservices/remoteModulesTracker.php
 /wp-content/plugins/asmb-tracking/*
@@ -18966,7 +16807,6 @@ _tracking.php?b=
 ! Tealium
 ! The site should be carefully checked when you add this rule
 ||tags.tiqcdn.com/utag/*/prod/utag.js$domain=radissonhotels.com|post.ch|usnews.com|d1lynpf6ndesae.cloudfront.net|rukrymr.azureedge.net|krymr.com|cnet.com|adidas.co.uk|adidas.nl|adidas.pl|lineadirecta.com|sibreal.org|modernatx.com|louisvuitton.com
-||tags.tiqcdn.com/utag/*/utag.sync.js$domain=yousee.dk|sibreal.org
 !
 !
 ! TODO: check the allowlist file from time to time to remove unnecessary exceptions
@@ -19007,7 +16847,6 @@ dealdoktor.de##img[src*="//vg09.met.vgwort.de/"]
 ||t2bot.ru/nod32key/adblock-c.php
 ||qoe-*.yottaa.net/*/configure.rapid.js
 ||naukatv.ru/nauka/statistics/
-||core.helloretail.com/serve/collect/pageview^
 ||girlsofdesire.org/images/girlsofdesire.org/analytics.js
 ||launchpad-wrapper.privacymanager.io/*/launchpad-liveramp.js
 ||laz-g-cdn.alicdn.com/lazada/dynamic-static-nopolyfill/*/daraz-marketing-tracker.js
@@ -19015,7 +16854,6 @@ dealdoktor.de##img[src*="//vg09.met.vgwort.de/"]
 ||cdn.privacy-mgmt.com/wrapper/metrics$important
 ||c2shb.pubgw.yahoo.com/admax/bid/partners/PBJS^
 ||mixnews.lv/wp-content/uploads/perfmatters/gtagv*.js
-||akakce.com/*/clickHeat/
 ||cdn.one.store/javascript/dist/1.0/jcr-widget.js$domain=hificentre.com
 ||lendingtree.com/path/api/track/
 ||api.tua.gov.tr/api/visitor_statistics
@@ -19055,17 +16893,14 @@ j-cast.com###cxRelatedEntry
 ||static.hepsiburada.net/scripts/webtrekk*.js
 ||haber365.com.tr/*/hitcount
 ||meetimgz.com/vtrack
-||fotocommunity.de/track/js/
 ||api.wikitree.co.kr/api/v*/postLog.php
 ||1gr.cz/log^
 ||gw.ganjing.com/v*/tracking-content
 ||d.bidmatic.io/tracking/
 markezine.jp##.carouselBlock > li[id^="cx_"].c-headlineindex_listitem
-||static.ex.co/cdn/content/monetization/pixel-sdk/
 ||cdn.nwl1.megaknihy.cz/tr.js
 ||vicodes.com/tag/load-*.js
 ||app.turbobiyt.net/js/analytics/index.js
-||sp.vtex.com/event-api/
 ||mall.tv/bundles/analytics?
 ||moe-online.ru/themes/default/front/js/stat/
 ||moe-online.ru/api/moe/stat/sendStat
@@ -19084,7 +16919,6 @@ ciudad.com.ar###cxense-wrapper
 ||hombex.com/assets/js/component/analytics.js
 ||data.clickocean.io/actions/
 ||pstatic.net/adimg3.search/adpost/
-||cope.es/stats/services/recordEvent
 ||maximum.ru/uploads/metrics.js
 ||zn.ua/actions/profile/banners/stat
 ||courrierinternational.com/bucket/*/js/standalone/at-internet.js
@@ -19096,7 +16930,6 @@ ciudad.com.ar###cxense-wrapper
 ||stats.publitas.com/publitas-stats/track
 ||clinique.com.tr/js-repo/elc-service-analytics/
 ||clinique.com.tr/sites/all/libraries/analytics/
-||clinique.com.tr/sites/clinique/themes/cl_base/js/shared/analytics.min.js
 ||turkiyegazetesi.com.tr/item/hit?
 ||rossmann.com.tr/checkout/analytics/
 ||chil-chil.net/cpAdShow/
@@ -19115,7 +16948,6 @@ ciudad.com.ar###cxense-wrapper
 ||digitaltrends.com/wp-content/themes/dt-stardust/assets/scripts/js/dt-metrics.min.js
 ||api.edkt.io/analytics
 ||aveda.com.tr/sites/all/libraries/analytics/
-||aveda.com.tr/sites/aveda/themes/aveda_base/js/shared/analytics.min.js
 ||diariodonordeste.verdesmares.com.br/static/assets/scripts/p_googletag.js
 ||clck.dzen.ru/click/$ping
 ||cp.hallo-eltern.de/stats
@@ -19148,7 +16980,6 @@ androplus.org##a[href^="https://px.a8.net/"]
 ||static.searchiq.co/t/pxl.gif
 ||kayak.co.kr/s/vestigo/*/measure^
 ||amd.sellingsimplified.net/wt/resource/js/track.js
-||screensaversplanet.com/js/analytics.js
 ||robert.golem.de/g/collect
 ||pornhub.com/js/eht.js
 ||yastatic.net/s*/milab/js/metrika-counter.js
@@ -19162,22 +16993,18 @@ androplus.org##a[href^="https://px.a8.net/"]
 ||secretcv.com/log/
 ||segodnya.ua/article/view/inc/*?counter_locale=
 ||exilelink.com/impression/
-||18comic.vip/templates/frontend/airav/js/td_js/td_ga_tracker.js
 ||was.livere.me/api/ad|
 ||trnox.com/ssp/ws/*/action/log?
 ||foursquare.com/*/collector/noScript.gif
 ||api.foursquare.com/*/logactions
 ||foursquare.com/*/logger
-||foursquare.com/*/wtrack?event=
 ||wix.com/_api/wix-laboratory-server/laboratory/conductAllInScope
 ||util.geeksforgeeks.org/post/api/usertracking
 ||developers.google.com/_d/analytics-iframe
 ||cdn-gl.nmrodam.com/conf/
 ||ardmediathek.de/tp/
 ||1ps.ru/cdn-cgi/challenge-platform/
-||skyscanner.com.br/*/collector
 ||sportskeeda.com/service-workers/helpers/google-analytics
-||3p-geo.yahoo.com/p?s=
 ||api.remanga.org/api/logging/
 ||bilet.yandex.com.tr/log/
 ||travel.yandex.ru/api/*/log/
@@ -19198,7 +17025,6 @@ androplus.org##a[href^="https://px.a8.net/"]
 ||super.cz/*/track?
 ||super.cz/*/jquery?$image
 ||mozilla.org/media/js/firefox_new_pixel.
-||bc.thestreet.com/DG/DEFAULT/rest/
 ||tiebac.baidu.com/*/log/
 ||sopoe.cn/index.php/user/ajax_ulog/
 ||businessmirror.com.ph/wp-content/plugins/wp-analytify
@@ -19241,23 +17067,18 @@ androplus.org##a[href^="https://px.a8.net/"]
 ||flaticon.com/_ga?
 ||snva.jp/api/bcon/$image
 ||animember.net/js/access.js
-||stmg-prod.mirror.co.uk/analytics.config.json
-||whistleout.com.au/track?u=
 ||trstx.org/stats/event
 ||kapi-office.yiche.com/apm_collect
 ||ga.yiche.com/autolog
 ||flux-cdn.com/*/analytics/
 ||um.viuapi.io/loggingservice/
 ||toneden.io/*/analytics/
-||bangkokpost.com/hits/*?t=
 ||androidauthority.com/track?u=
 ||yemeksepeti.com/*/xhr/api/*/collector
-||yemeksepeti.com/*/xhr/b/s/beacon
 ||statistics.aldi-international.com/consent/collect
 ||api.reverso.net/stats/
 ||cdn.reverso.net/rumjs/
 ||cdn.reverso.net/ramjs/
-||cc.loginfra.com/cc?a=$image
 ||cc.naver.com/cc$image,redirect=2x2.png
 ||cc.naver.com/cc$other,ping
 ||api.eduki.com/*/track
@@ -19283,13 +17104,10 @@ androplus.org##a[href^="https://px.a8.net/"]
 ||cdn.fast.beintoo.net/static/tags/beintoo-tag.js
 ||twivideo.net/templates/ajax_link_click.php
 ||zenmatefeedback.typeform.com/forms/*/insights/events/
-||express.co.uk/analytics.config.json
 ||media.flixcar.com/delivery/js/hotspot/
 ||api.teester.com/data/collect
 ||ucankus.com/inc/hhit.asp
-||a.rltd.io/tags/kpt.js
 ||realtym.live/ga.js
-||francais.rt.com/nbc-stats/
 cienradios.com##article[class^="cXense-"]
 ||app.responsivevoice.org/analytics/
 ||libs.platform.californiatimes.com/meteringjs/
@@ -19299,7 +17117,6 @@ cienradios.com##article[class^="cXense-"]
 ||popin.cc/conversion2.js
 ||ext.chtbl.com/trackable.js
 ||karelcapek.co.jp/Scripts/tracker.js
-||static.iyzipay.com/buyer-protection/assets/js/analytics.js
 ||academia.edu/v0/pv?
 ||coocha.co.kr/log/
 ||recobell.io/rest/logs
@@ -19309,8 +17126,6 @@ park.ajinomoto.co.jp##.bottomMenu
 ||static1.dmcdn.net/playerv5/dmp.pes_pip_tracking.*.js
 ||go.mgdjmp.com/eye.gif
 ||go.xhamster*.*/eye.gif
-||customfingerprints.bablosoft.com/clientsafe.js
-||cdn.melhorplano.net/scripts/tracker/mpt.min.js
 ||retently.com/api/remote/tracking/
 ||web-g-p.com/info/js/cookie.js
 ||web-g-p.com/info/log/
@@ -19320,7 +17135,6 @@ newsdig.tbs.co.jp#?#.l-contents-wrap > div[v-scope^="Recommend"]:upward(1)
 ||kraken.com/js/sift.min.js
 ||javynow.com/ajax/access.php
 augsburger-allgemeine.de,nikkansports.com##div[id^="cx_"]
-||outlook-1.cdn.office.net/owamini/*/resources/analytics-ping.js
 ||rocket.ivi.ru/event/
 ||g.ivi.ru/track
 ||duckduckgo.com/*/reportAnalytics
@@ -19345,7 +17159,6 @@ weekly-economist.mainichi.jp##iframe[id^="cxWidget_"]
 ||websiteplanet.com/wp-content/themes/websiteplanet/js/header-footer.js
 ||portalcms.bm5.pl/Stat/statystyki.aspx
 ||hentai.name/js/track.js
-||demo.zeenews.com/ads/counter.php
 ||b2b.ainews.kz/script/v*/ainews-click.js
 ||rokt.com/v1/events^
 ||rokt.com/v2/metrics^
@@ -19359,7 +17172,6 @@ weekly-economist.mainichi.jp##iframe[id^="cxWidget_"]
 ||virtualcarshop.jp/js/ga.js
 ||info.biz.nuro.jp/analytics?
 ||bo.kodflix.com/statsclick.php
-||twitter.com/1.1/jot/client_event.json
 ||google.*/maps/*/log
 /\/js\/[a-z]{3}\d\.js$/$script,1p,domain=eegg.fun
 ||s-cdn.phonearena.com/js/ops/taina.js
@@ -19404,8 +17216,6 @@ chinatimes.com##.popin-recommend
 ||cdn.lr-in.com/logger-1.min.js
 ||cdn.lr-in.com/LogRocket.min.js
 ||popularwidget.com/tracker/
-||share.9cdn.net/share/long_cache/js/tracking/
-||visumo.jp/Content/js/tracking.js
 ||services.wiseadvice.ru/tracker/js/*/wa.min.js
 ||n.tooplay.com/s?v_unique=
 hobbylog.jp##.pbancut
@@ -19444,7 +17254,6 @@ agronews.com##a[alt="Яндекс.Метрика"]
 ||api.clerk.io/v*/log/
 ||compress-or-die.com/hokuspokus
 ||vid*/stats/event
-||tpucdn.com/js/ga-*.js
 ||techpowerup.com/__botcheck
 ||metric.cryptofans.asia/scripts/track_conversion.js
 ||purr.nytimes.com/*/purr-cache
@@ -19455,28 +17264,22 @@ agronews.com##a[alt="Яндекс.Метрика"]
 ||api.rbsmi.ru/site/*/counter/
 ||estar.jp/access?status=
 ||linkinprofile.com/api/v1/raw_page_view_stats
-||idat.production.ippen.space/idat
 ||imfernsehen.de/z/z.inc.php
 ||api.blockchain.info/events/tracking/consent
 ||action.adoffice.11st.co.kr/act/
 ||mediatrend.kr/aiDataTrigger?uri=
 ||glami.com.tr/tracker/
 ||api.phnx.click/js/article-stat-
-||wondershare.cc/js/sensorsdata.min.js
 ||wondershare.com/wsid/com/static/utils/track.js
 ||harvester.joj.sk/api/v1/harvester.js
-||kazi.co.jp/js/analytics.js
 ||crunchbase.com/*/collector|
-||docomo.ne.jp/js/beacon.js
 ||100widgets.com/stat.js.php
 ||scinable.net/access?vid=
 ||shopify.com/*/site-tracking.php?
 ||linkedin.com/pixel/
 politring.com##a[href="https://metrika.yandex.ru/"]
 ||tcloudbase.com/access?
-||static-cdn.tinkoffjournal.ru/js/analytics.*.js
 ||rlsnet.ru/js/statistics/
-||std-lab.jp/js/analytics.js.php
 ||gplinks.co/auth/ads_stats_controller.php
 ||mynewsmedia.co/*/linkpage/ads_stats_controller.php
 ||infusionsoft.com/app/webTracking/getTrackingCode
@@ -19500,7 +17303,6 @@ politring.com##a[href="https://metrika.yandex.ru/"]
 ||st.work.ua/js/site_counters-min_*.js
 ||st.work.ua/js/send_stat-min_*.js
 ||st.work.ua/js/banners/global-counter-min_*.js
-||work.ua/analytics/view-page/
 ||srv.onedio.com/counter/
 ||api-onedio-lambda-production.onedio.com/srv/counters/
 ||cdnen.rt.com/static/js/libs/counters.js
@@ -19527,7 +17329,6 @@ nlab.itmedia.co.jp##div[id^="logly-"] + div.h10px.colBoxClear
 ||autonews.ru/redir/stat/
 ||cdn.ticimax.com/*/analytics.js
 ||esgazete.com/service/social-counter.json
-||commons.dw.com/tracking/smarttagJwPlayerPlugin.js
 today.ua##.li-bi-container
 ||wurking.global.ssl.fastly.net/ingestly-ingest/
 ||rjno1.com/cdn-cgi/challenge-platform/h/b/scripts/invisible.js
@@ -19550,7 +17351,6 @@ news.biglobe.ne.jp##div[style="min-height: 610px"]
 ||crozdesk.com/tracker/
 ||clearbit.com/*/fingerprint
 ||chimpstatic.com/mcjs-connected/js/
-||dailymail.co.uk/geo/edgedata.html
 ||paypalobjects.com/web/res/*/js/summary-analytics.js
 ||123recht.de/include/menu/header-stats.asp
 ||carfixer.co.kr/log/
@@ -19592,7 +17392,6 @@ chaos2ch.com###sub div.plugin-memo:last-child
 ||kraken.com/analytics
 ||lastpass.com/m.php/loadanalytics2
 ||dspnow.ru/beacon/
-||grammarly.com/api/tracking/
 ||static.vocstatic.com/tag-manager/latest/vtm.js
 ||bilibili.com/x/frontend/finger/fpfmc?
 ||components.justanswer.com/v3/main-tracking-script@released.js
@@ -19603,7 +17402,6 @@ komachi.yomiuri.co.jp##._popIn_ranking_otekomachi
 komachi.yomiuri.co.jp##._popIn_recommend_tieup
 ||you.com/api/events
 ||udemy.com/api-2.0/ecl?
-||sqs.quoka.de/logsearch.php
 ||receive.shamimomo.net/dream/dream.cgi
 ||prokazan.ru/components/analytics/stat.js
 ||progorodchelny.ru/modules/lenta/stat.php
@@ -19628,37 +17426,27 @@ textologia.ru##.bot_right
 ||daisomall.co.kr/collect.php
 ||contents-search-windows.com/api/v1/x^
 ||sobaka.ru/assets/*/countersApi.js
-||onedaythreeautumns.com/api/census/RecordHit
 ||api-web.pressplay.cc/marketing^
-||flog.pressplay.cc/batch_track^
 ||spush.toptoon.com/log/
 ||rfk.finishline.com/api/event-rfkj/
 ||cams.xnxx.com/pixel/
 tourister.ru##.nt-foot-item[style="overflow:hidden;"]
 ||pravo.ru/assets/*/js/event.js
-||mercury.coupang.com/e.gif?
-||lemonde.fr/bucket/*/js/smartTag.bundle.js
 ||fivemsociety.com/analitik.js
 ||baseendpoint.stern.de/wrapper/metrics
-||bs.yandex.ru/count/
 ||trk.mail.ru^$image,ping
 ||push.m.youku.com/collect-api/
 ||cast.imp.joins.com/persona.js
-||imptrack.intoday.in/impression_tracker.php
 ||tosshub.com/sites/common/resources/trackdata/min/itgdtrack*.js
 ||api2.bybit.com/v2/public/metrics
 ||api.*.com/p/report?$domain=bybit.com
-||statnews.com/wp-content/compiled/js/stat-adobe-analytics.js
-||statnews.com/wp-content/compiled/js/stat-dfp.js
 ||justmyshop.com/common/lib/f_ad_code.js
 ||hankookilbo.com/statistics/uv?
-||evt.mxplay.com/v*/client/*/records
 ||blozoo.info/js/inouttool/
 ||blozoo.info/js/ranktool/
 ||blozoo.info/js/reversetool/
 ||oculus.com/ajax/bz?
 /images/onebyone.gif$domain=khan.co.kr|hani.co.kr
-||r3.mail.ru/k?sign=
 /api/events|$domain=boticario.com.br|livehdcams.com|pornhublive.com|hog.tv|eudora.com.br|belezanaweb.com.br|vult.com.br|quemdisseberenice.com.br
 ||images.tcdn.com.br/commerce/assets/store/js/dist/facebook-conversion.js?pixel=
 ||indeed.com/api/datadog-rum/?
@@ -19666,7 +17454,6 @@ tourister.ru##.nt-foot-item[style="overflow:hidden;"]
 ||indeed.com/api/v0/user/backendLog?
 ||indeed.com/*/log^$ping
 ||indeed.com/rpc/timing?logEvent=
-||indeed.com/m/rpc/log/
 ||indeed.com/m/rpc/frontendlogging
 ||static-img.threatbook.cn/zhugeio/zhuge.js
 ||idcdn.de/static/common/js/build/modules/*/id.clickTr.js$domain=tz.de
@@ -19680,16 +17467,12 @@ tourister.ru##.nt-foot-item[style="overflow:hidden;"]
 fategrandorder.info##.sidebar_acr.side_inline
 ||emea.flow.microsoft.com/providers/Internal.Telemetry
 ||glbimg.com/vendor/libs/comScore-*.min.js
-||dlswbr.baidu.com/heicha/mw/abclite-*.js
 ||az416426.vo.msecnd.net^$3p
-||cloudfront.net/js/sauron-analytics/stable/sp.js
 ||api.biggylabs.com.br/track-api/
 ||statcounter.com/counter/*.js
 ||hector.baidu.com/static/h.gif?
 ||twowheeler.policybazaar.com/js/GTMgoogleAnalytics.js
-||re-doing.com/st-manager/pv-monitor/impression/track?
 ||ahentai.top/counter.php
-||cdn.jsdelivr.net/npm/@adshield/
 ||gizmodo.com/x-kinja-static/assets/*/trackers.
 ||img-kotonw.mncdn.com/*/acc.clickandcollect.js
 ||ecoms.koton.com/ma/collect
@@ -19700,12 +17483,8 @@ fategrandorder.info##.sidebar_acr.side_inline
 ||zerkalo.io/api?rev=r0~r0~r0
 ||app.notipack.com/pixel-track?
 ||macpaw.audw.net/i/
-||valueresearchonline.com/assets/js/gtag.js
 ||cache.ltn.com.tw/js/c.js
-||maillist-manage.eu/*/ActionLogger?
-||api.pico.tools/metrics/
 ||vantastic-foods.com/dlyx/tms.js
-||dojq4kt8ws9iq.cloudfront.net/js/analytics.js
 ||corriere.it/apw.js
 ||components2.corriereobjects.it/rcs_data-tracking/
 ||components2.rcsobjects.it/rcs_tracking-service/
@@ -19714,15 +17493,11 @@ fategrandorder.info##.sidebar_acr.side_inline
 ||geoip.olx.com.br^
 ||pub.olx.com.br/listing.js
 ||pub.olx.com.br/detect-adblocker.js
-||static.olx.com.br/olx/js/lurker.min.js
 ||cio.economictimes.indiatimes.com/ajax_files/etb2b_ajax_trackers.php
-||idm.economictimes.indiatimes.com/personalisation/logdata/
-||dash.getsitecontrol.com/api/*/events?
 ||dynatrace.com^$domain=~dynatracelabs.com|~dynatrace.com
 ||postback.affiliateport.eu/track.js
 ||mlstatic.com/analytics/
 suara.com##.dailymotion-widget
-||sgtm.fashionunited.de/gtm.js
 ||cmp.p7s1.io/*/analytics
 ||app.watchthem.live/pixel-track/
 ||cdn.shopify.com/s*/trekkie*.js
@@ -19732,26 +17507,19 @@ suara.com##.dailymotion-widget
 ||gillette.com/index.php?action=track_
 ||deine-tierwelt.de/external/analytics.js
 ||deine-tierwelt.de/static/js/*tracking.js
-||p.rst.im/q/www.googletagmanager.com/gtag/js?id=
-||houzz.com/js/log?p=
 ||admin.guide-rank.com/guiderank-tracking/
 ||image.ruliweb.com/view/log
-||odnoklassniki.ru/dk?cmd=videoStatNew
 ||opensubtitles.org/gfx/banners_campaigns/2x2.gif
 ||ias.r10s.jp/grp15/ex_common2.js
 ||adn-srv.reckoner-api.com/v1/ad/
 ||smaero.jp/js/access.js
 audiobb.com##.sidebar > #custom_html-4
-||allure.com/hotzones/src/pixelpropagate.js
 ||clustrmaps.com^$image,redirect=1x1.gif,3p
 ||proxycheck.io/v*/?key=$3p
-||smassets.net/assets/anonweb/anonweb-click-logger-bundle-
 ||yahoodns.net/pixel.gif
 ||60a6ae725fca.bitsngo.net/widget-scripts/zoomd.widget.logger.min.js
-||http2.mlstatic.com/analytics/ga/mla-ml-analytics.min.js
 ||api.mercadolibre.com/tracks
 ||bestbuy.com/~assets/bby/_js/ext/bbydyn/dyn_digital_gvp.js
-||whirlpool-cdn.thron.com/shared/plugins/tracking/current/sp.js
 ||cmp.focus.de/wrapper/metrics^
 ||daimaoh.co.jp/afimp.php?
 ||sp.pluto.tv/com.snowplowanalytics.
@@ -19760,8 +17528,6 @@ audiobb.com##.sidebar > #custom_html-4
 ||rigvedawiki.net/r*/referer.php
 ||content.garena.com/shopee/track_config/
 b.kyodo.co.jp##.banner-area-entry + h3.category-title
-||global.canon/00cmn/js/*/analytics-$script
-||40svintageporn.com/hit|
 ||linkedin.com/li/track^
 ||namu.wiki/i/*?um_name=
 moeimg.net###pickup-header_frame
@@ -19771,7 +17537,6 @@ moeimg.net###pickup-header_frame
 ||api.tinypass.com/api/v*/anon/error/log
 ||xiaohuangshu.me/visit.php
 4esnok.by###text-17
-||searchiq.co/api/tr?event=
 ||platform.datazoom.io/beacon/
 ||nicovideo.jp/api/tkas_video_impression
 ||nvapi.nicovideo.jp/*/bandit-machine/
@@ -19784,7 +17549,6 @@ pusatporn18.com###HTML1
 ||industrystock.de/ajax/track.php
 komachi.yomiuri.co.jp##.topi-popin-relation
 otekomachi.yomiuri.co.jp###_popIn_right
-||jsdelivr.net/npm/keen-tracking@*/keen-tracking.min.js
 ||visumo.jp/MediaManagement/WebApi/PageView?
 ||low-ya.com/duplicate-ga-cookie
 ||qgraph.io/dist/aiqua-wp.js
@@ -19804,7 +17568,6 @@ petyado.com##table[width="785"][height="30"]
 petyado.com##td[valign="top"][height="10"] > table[width="795"]
 ||action.metaffiliation.com/trk.php
 ||d2-apps.net/js/tr.js
-||taptap.*/webapiv2/log/
 ||vc.ru/px.gif
 ||misumi-ec.com/api/v1/log/
 ||misumi-ec.com/vcommon/common/js/karte.js
@@ -19815,19 +17578,14 @@ seshop.com,shoeisha.co.jp###cceol
 /wp-content/plugins/google-analytics-dashboard-for-wp/*$domain=xpornass.com|vitacig.eu.com
 ||static.vocento.com/tag-manager/latest/vtm.js
 ||cdn.jsdelivr.net/npm/rrweb@latest/dist/rrweb.
--vlybypoc2019.cloudfunctions.net/vtrack?vid=
 ||zozo.jp/common/js/ads-inner-tracking.js
-||service.smarthint.co/track/
 ||api.biggylabs.com.br/event-api/
-||tetori.link/share/js/tracking.js
-||bauen-und-heimwerken.de/myphpfiles/js/analytics.js
 ||creema.jp/ad/click-log
 ||creema.jp/ad/impression-log
 ||www.google.*/velog/
 ||data.gov.in/ogdp-stats-
 ||xn--pckua2a7gp15o89zb.com/api/tracking.js
 ||indeed.com/indeedapply/tracking/
-||indeed.com/rpc/vjslog?
 ||cnt-*.svc.iptv.rt.ru/event_collector
 ||honda.co.jp/common/beacon/
 sports.goo.ne.jp###taboola-below-sokuho-thumbnails
@@ -19835,30 +17593,22 @@ sports.goo.ne.jp###taboola-below-sokuho-thumbnails
 ||wazzup.me/libs/track.js
 ||imstream.jp/analytics/js/
 ||stbbs.afreecatv.com/api/*_log.php
-||wataugademocrat.com/shared-content/art/stats/common/tracker.js
 ||shutto.com/images/pv_beacon.gif
 ||terabox.com/statistics^
 ||terabox.com/api/analytics
 ||video-library.showheroes.com/player/ad_tag?
-||cs.pikabu.ru/apps/ub/*/main/analytics.js
 ||pikabu.ru/ajax/save_stories_stat.php
-||arca.live/cdn-cgi/rum?
 ||*report.wc.yahoodns.net/cs/
 ||yahoo.net/pixel*.gif
-||wp.aliexpress.com/trace.gif?event=
 ||frog.wix.com^$ping,xhr
 ||cloudfunctions.net/conversionEventCondition|
-||cloudfunctions.net/trackEvent|
 ||hepsiburada.com/webcontent/
 ||images.hepsiburada.net/webtrekk/webtrekk.js
 ||hardwarezone.com.sg/js/hwz/hwzgtm.js
-||img*.en25.com/i/elqCfg.min.js
-||tweakers.net/*/event-tracking/
 ||ajinomoto.co.jp/shared_file/js/header_log.js
 ||ajinomoto.co.jp/shared_file/js/log.js
 ||bilanx.dtto.com/*/configs
 ||bilanx.dtto.com/*/events
-||mt-wzb.clarin.com/weizenbock/pixel.fingerprint.gif
 mag.osdn.jp##div[id^="logly-lift-"]
 ||mangapedia.com/js/abb.
 ||sf-syn.com/conversion_outbound_tracker$frame,domain=sourceforge.net
@@ -19866,7 +17616,6 @@ mag.osdn.jp##div[id^="logly-lift-"]
 ||play.tv3.lt/static/scripts/trackdb/events.gif$image,redirect=1x1.gif
 ||analytics.google.com/g/collect?*&tid=
 ||ssl.kaptcha.com/collect/
-||r.popin.cc/log.gif
 ||adsystem.dailyissue.co.kr/show/logs.php
 ||kgnews.co.kr/weblog/gtracker.
 ||l2.revotas.com/trc/api/rvts*_tracker.js
@@ -19879,58 +17628,43 @@ techmaniachd.pl###sidebar-right-1 > #HTML6
 ||walmart.com/px/
 ||cyberpedia.su/count.php
 ||con.arbeitsagentur.de/prod/matomo/
-||facebook.com/ajax/bz?*__comet_req=
 ||inthenews.co.kr/weblog/gtracker.
-||s3.ap-northeast-2.amazonaws.com/adpick.co.kr/apis/apTracker.v*.js
 ||cdn.pmweb.com.br/df/tag.js
 ||insider.com/chunks/scripts/datadog-
 ||webtoon.daum.net/common/click?
 ||log.nordot.jp^$xhr
-||cdn.calltrk.com/companies/
 ||fresheye.com/s.gif
 viva.ua##.footer-counters
-||google.*/imgevent?
 ||informazione.it/detroitchicago/cmb.js
 ||gamestar.de/*/index.cfm?event=tracking:
 ||rihappy.com.br/Site/Track.aspx
 ||vteximg.com.br/scripts/track.js
-||mediasetplay.mediaset.it/static/webtrekk/*/smart-pixel.min.js
 ||vtex.com.br/portal-ui/*/scripts/vtex-analytics.js
 ||rihappy.com.br/api/sessions?items
 ||vteximg.com.br/scripts/vtex.tagmanager.helper.js
 news.mynavi.jp##.articleList-along
 news.mynavi.jp##.articleList-attention
 ||t.rentcafe.com/rctv*.min.js
-||static.talpanetwork.com/prod/js/components/talpa-analytics/
 ||tasclap.jp/static/logger.js
 ||dubox.com/statistics^
-||fastcdn.co/js/sptw.js
 ||cloud.weborama.design/nonio.js
 ||comunidade.globalmediagroup.pt//tracker/tracker.ashx
 ||analytics.google.com/g/collect?v=
-||google.*/ads/ga-audiences?v=
 ||events.genndi.com/tracker
 ||mcrypto.club/track
 .php?p=stats$domain=ahwaktv.tv
-||stats.autoscout24.ch/tp.gif
 ||codeproject.com/a.min.js
 /yozons-lib/*$script,1p,domain=bradenton.com
-||res-ga.smzdm.com/gtm.js
 ||data.bilibili.*/log/
 ||stuttgarter-zeitung.de/cms/hitcount
 ||asahibeer.co.jp/tracking.js
 ||info.ryte.com/analytics
 ||app.carnow.com/dealers/track_visitor
-||app.carnow.com/dealers/visitor_info?
 ||hondacarsrockhill.com/pixall/pix-ddc-fp.min.js
 ||servebom.com/event.js
 ||flipkart.net/*/*/tracker/
-||content.viralize.tv/track/
 ||reddit.com/counters/$xhr
-||duhnet.tv/*/*/stats/init.min.js
-/track-internal-links.js$domain=balkangunlugu.com.tr
 ||tv-tokyo.co.jp/index/scatalyst/
-||reach-id.orbit.tm-awx.com/analytics.js.gz
 ||kmib.co.kr/NetInsight/trace/track
 ||idm.skplanet.com/pixel
 ||tend-table.com/cgi-bin/WebLog.dll
@@ -19938,42 +17672,28 @@ semprotyuk.com##div[style^="margin-bottom:150px;"][style*="padding-right:2em;"]
 ||googleoptimize.com/optimize.js$3p
 ||px.redgifs.com/px.gif
 ||cdn.cohesionapps.com/cohesion/xs1.html?xsid=
-||ingest.make.rvapps.io^$domain=zdnet.com
 ||hif.to/rkstat/
-||sailthru.com/horizon/track?*http$image,domain=bookriot.com
 ||hubpages.com/ctracker/
 ||owlcation.com/.bootscripts/hubPages*Tracker.min.js
-||api.nvidia.partners/telemetry/
-||static.hankyung.com/js/ga/googleTagManager.js
 ||hankyung.com/resource/js/w/view.gtmet.js
 ||cdn.thunderhead.com/one/rt/js/one-tag.js
 ||discord.com/api/v*/science
-||fensi.plus/*/tracking/
 ||tvid.in/sdk/loader.js
-||tvid.in/log/logs
 ||intersc.igaming-service.io/hltv.org.js
 ||za.zalo.me/v*/brp?fts=
 ||za.zalo.me/v*/w/_zaf.gif
 ||api.eigene.io/rec/
-||guj.de/js/gujTracker.js
 /tracking.js$domain=schoener-wohnen.de|deichmann.com
-||snva.jp^*/beacon.js
 /js/tracking-*.js$domain=cinkciarz.pl|conotoxia.com
 ||70url.com/paody/js/count.js$domain=yingwangtv.com
 ||85st.com/static/js/logging.js
 ||ads-partners.coupang.com/log/
 ||pla.naver.com/log/
 /universal_analytics.$domain=foerde-sparkasse.de
-/AppMeasurement.js$domain=channel4.com
-/AppMeasurement_Module_ActivityMap.js$domain=channel4.com
 ||gold.contentsfeed.com/lb/sd/nw$domain=sportsseoul.com
 ||gtr1.yes24.com/wlo/Logging
 ||analytics.fsho.st/tracker.js
-||a.poki.com/observer/$script
-||wcs.naver.com^$image
 ||las.danawa.com/log/
-||tmgrup.com.tr/videojs/js/lib/streamsense.min.js
-||insight.danawa.com/InsightTrk/*.do
 ||news.chosun.com/svc/fb_count.html
 ||news.chosun.com/dhtm/*/collecter.js
 ||openapi.tv.zum.com/logs/ad/
@@ -19988,40 +17708,26 @@ club-opel.com##.toplist
 israelnationalnews.com,insider.com##.taboola
 ||byjus.com/byjusweb/js/tracking-2.min.js
 ||ccpa.sp-prod.net/ccpa.js
-||static1.dmcdn.net/js/cpe/cpeEvent.min.js
 ||embedly.com/widgets/xcomm.html^$3p
-||vidtech.cbsinteractive.com/uvpjs/*/lib/tracking/mux.js
-||vidtech.cbsinteractive.com/uvpjs/*/lib/tracking/adobe/
-||turner.com/analytics/comscore/streamsense.
 ||episerver.net/ia.gif?r=
 ||wikihow.com/x/collect
 ||peerius.episerver.net/tracker/
 ||imgsen.com/vtrack
 ||gratis.com/ccstoreui/*/analytics/visitorsMetric
-||h.seznam.cz/hit/?
 ||dacota.tw/wp-content/plugins/wp-mop-analytics/
 ||cn.ntdtv.com/assets/themes/ntd/js/article_ads.js
 the-ans.jp##.side-reccomend
 ||googleadservices.com/pagead/conversion_async.js$script,redirect=noopjs,domain=orcd.co
 ||cdn.omuz.com.tr/connect/pub-min.js
 ||static.solarwinds.com/referrer-cookie.js
-||vidtech.cbsinteractive.com/*/lib/tracking/adobe/VideoHeartbeat-
-||at.cbsi.com/*/event?
 ||sprocket.bz/trackers/
-||cdn.digitaloceanspaces.com/pixel/lp.js
-||maillist-manage.com/wa/ActionLogger?
 ||softland.co.kr/exec/front/eclog/
 ||softland.co.kr/app/Eclog/js/cid.generate.js
 ||push.soft-com.biz/api/ui/metrics
-||cdn.megadata.co.kr/dist/prod/enp_tracker_
-||image.cauly.co.kr/script/caulytracker_async.js
 ||scv.band.us/jackpotlog/*/logs
-||gate.upclick.com/btn/visitor.min.js
-||macg.co/modules/statistics/statistics.php
 ||bilanx.dcard.tw/*/configs
 ||bilanx.dcard.tw/*/events
 ||mhevent.segye.com/mbi/pvcount
-||img.sportsworldi.com/static/w_sportsworld/common/js/analytics.js
 ||crunchyroll.com/tracker
 ||sa.crunchyroll.com/analytics.js
 ||laurenhi.com/app/Eclog/
@@ -20037,8 +17743,6 @@ the-ans.jp##.side-reccomend
 ||a*.pr-cy.ru/stat/
 ||sportsseoul.com/news/site_log/
 ||comic.naver.com/ad/flex/stats.nhn
-||res.heraldm.com/js/acecounter_*.js
-||res.heraldm.com/js/logcollectscript_*.js
 ||app.revhunter.tech/px^
 ||cdn.cohesionapps.com^$domain=gamespot.com
 ||m-economynews.com/weblog/gtracker
@@ -20048,7 +17752,6 @@ the-ans.jp##.side-reccomend
 ||home.ebs.co.kr/ebsnews/logProce/logAjax
 ||pb.m.naver.com/abpblock
 ||ewaline.su/stats.js
-||data.html5games.com/event/ad
 ||bbc.com/ngas/latest/dotcom-analytics.js
 ||piano.io/tracker/$domain=inc42.com,important
 ||nocutnews.co.kr/js/logger*.htm
@@ -20062,9 +17765,6 @@ the-ans.jp##.side-reccomend
 ||zenback.jp^*/tracking.html
 ||cdn.retailrocket.*/*/tracking.js
 ||ru-mi.com/*/ee_tracking.js
-||matchid.adfox.yandex.ru/getcookie$domain=vseinstrumenti.ru|kp.ru
-||player.vzaar.com/libs/googleAnalytics/vzaarGoogleAnalytics.js
-||r.yna.co.kr/global/lib/*/js/nlogger.js
 ||uol.com.br/*/stats^
 ||clck.yandex.ru^$other
 ||dubox.com/api/analytics
@@ -20076,12 +17776,9 @@ the-ans.jp##.side-reccomend
 ||mybbc-analytics.files.bbci.co.uk^
 ||api-cf.affirm.com/api/v*/session/touch_track
 ||101.ru/api/counters/
-||d21gpk1vhmjuf5.cloudfront.net/unbxdAnalytics.js
 ||tiava.com/js/analytics
 ||fuq.com/js/analytics
-||cdn.jsdelivr.net/npm/perfops-rom$domain=kropic.com|opensubtitles.org
 ||24support.cc/js/stats.js
-||static.me.me/static/versions/js/external/google_analytics-*.js
 ||webryblog.biglobe.ne.jp/beacon/
 ||wowgame.jp/countup.asp
 inside-games.jp##.cx-subhead
@@ -20096,14 +17793,11 @@ inside-games.jp##.cx-subhead
 ||wp-r.github.io/*/assets/js/jquery.iframetracker.js
 business.nikkei.com##.cbCxense
 koneta.nifty.com###custom_html-2
-||api.aws.mapquest.com/logger
-||mysexgames.com/statstracker.php
 ||churchtechtoday.com/?wordfence_lh=
 ||playep.pro/pl/vendor/stat.min.js
 ||computerbase.de/api/consent-analytics
 ||smutty.com/ajax/trcking/
 ||spechy.live/spechyAnalytics/spcwganalytic.js
-||atconnect.npo.nl/h?s=$image
 ||supleks.jp/action/log/
 ||pendo.io/data/ptm.gif
 ||vk.com/rtrg$3p
@@ -20111,21 +17805,16 @@ koneta.nifty.com###custom_html-2
 ||conduit.com/drawtoolbar/
 ||fccinteractive.com/tracking/
 ||idg.se/3/idg/
-||qihoo.com/stat.gif?
 ||ratteb.com/js.
 ||seotoolset.com/pathmaps.
 ||sohu.com/track/
 ||nate.com/stat/
 ||hexun.com/js/count.
 ||hexun.com/track/
-||c.lazada.co.id/t/v.gif?__t=
-||hm.baidu.com/hm.gif
 ||m.baidu.com/tc?tcreq4log=
-||virtualearth.net/webservices/v*/LoggingService/LoggingService.svc/Log?entry=
 ||s3.amazonaws.com/maropost/
 ||assets.vidora.com/*/validate?api_key=
 ||ty90nwjc8wjt-a.akamaihd.net^$domain=nypost.com
-||af.analytics.elx.cloud^$domain=arbetsformedlingen.se
 /gtm-*.js$domain=livingtraditionally.com|myhealthgazette.com|kediportal.com|koinbulteni.com|teknop.net
 ||newstm.in/stats?
 ||newstm.in/static/ase/at/at.js
@@ -20133,17 +17822,12 @@ koneta.nifty.com###custom_html-2
 ||cdn.dopc.cz/gen/detect.png
 ||digikey.*/-/media/Designer/Web%20Analytics/MultiTrack/JS/multitrack.js
 ||digikey.*/resources/ba4e6e570brn21616213e20fbeb902d9
-||app.convertkit.com/forms/*/visit
 ||chronicle.com/_track
 ||construction21.org/ga.js
-||api.idg.zone/intextlinks-tracking/
 ||prometeo-media-service.com/assets/pixel.gif
-||capi.connatix.com/tr/
 ||i.milliyet.com.tr/D/j/Molatik/GoogleAnalit.js
 .co/gc?id=$domain=nzma.org.nz
 /kukulufinger2.js$domain=erinn.biz|kuku.lu
-||static-lvlt.xhcdn.com/js/track.min.js
-||source.mmi.bemobile.ua/cm/
 vulture.com##div[data-uri="www.vulture.com/_components/clay-space/instances/taboola@published"]
 ||beget.com/p$image,3p
 ||ae.dmxleo.com/*/events
@@ -20152,95 +17836,58 @@ vulture.com##div[data-uri="www.vulture.com/_components/clay-space/instances/tabo
 ||gizmodo.jp/api/SurveyCountCollection
 android-tools.ru###text-8
 ||open-s.alibaba.com/openservice/userBehaviorProductViewService
-||arms.aliyuncs.com/r.png
 ||stats.viqeo.tv^
-||links.services.disqus.com/api/ping
 ||nikkei.*/SC/
 ||nikkei.*/SC2/
 ||i.bcicdn.com/js-min/*/chunks/8.*.js
 ||martechsecresponse.s3.us-east-2.amazonaws.com/HotelTracker-*.js
-||my.mail.ru/dstat?random=
 ||expedia.nl/trvl-px/
 ||a.cdn-hotels.com/cos/travel-pixel/
-||static.wellsfargo.com/tracking/
-||wellsfargo.com/assets/images/global/s.gif?log=
 ||wellsfargo.com/tas|
 ||tweakers.net/x/scripts/min/ptBO.js
 ||franeski.net/js/lib.js
-||api.trwl1.com/ascripts/gcrt.js
 ||main.exoclick.com/tag.php
-||static.dditscdn.com/arms-datacollectorjs/
 ||cs.*/pixeljs|
 ||zaycev.net/clickmeter_
 ||cdnst.zaycev.net/static/*/countersm.js
 ||highwebmedia.com/CACHE/js/output.ed5f5a28fb27.js
 ||foodclub.ru/bitrix/tmp/fd_tmb/f.php
 ||bursadabugun.com/haber/imp-
-||i.jsrdn.com/i/1.gif?
 ||api.impresa.pt/trackercookie
-||linkedin.com/sensorCollect/?action=
 ||api.phoenix-widget.com/c?wid=
-||gazeta-unp.ru/viewCounter/increment
 ||computerbase.de/api/nlytcs
 ||dl8.me/*.gif?
-||eec.crunchyroll.com^$domain=crunchyroll.com
 ||cr-eec.etp-prod.com^$domain=crunchyroll.com
-||eec.crunchyroll.com/v*/track
 ||zone-telechargement.ninja/bypassmajs
-||static.cloudflareinsights.com/beacon.min.js
 ||eiga.k-img.com/javascripts/td.js?1578981009
-||api.smg.com/Etrack/
 ||klarnaservices.com/?a=$image
-||vimeocdn.com/add/player-stats?beacon=
 ||signin.ebay.com/t_n.html
 ||s3.glbimg.com/cdn/libs/element-tracker/*/element-tracker.min.js$domain=globo.com
-||tags.globo.com/utag/globo/*/prod/utag.js
-||elitepvpers.com/epvplytics.
 ||trinklink1.s3.amazonaws.com/trinklink.js
 ||myaccount.exeterfinance.com/Scripts/App/google_analytics.js
 ||dec.azureedge.net/sdk/telerik-dec-client.min.
-||adlc-exchange.toast.com/sendid?sid=
 ||techstage.de/js/techstage/webtrekk_scrollposition.js
 ||n-tv.de/stats^
 ||media.miamiherald.com/miamiherald/ng.gif?
 ||vs4.com/impr.php
-||cdns.gigya.com/js/gigyaGAIntegration.js
-||leadpages.net/*/tracking.js
 ||api.leadpages.io/analytics/$domain=~my.leadpages.net
-||heute.at/*/render/common/js/tracking.js
-||pv.ltn.com.tw/impression?
-||pv.ltn.com.tw/RI_Server?a=
-||chesterstandard.co.uk/resources/static/standard/texts/js/VisitorAPI.js
 ||cdn.abcotvs.net/abcotv/assets/news/global/js/analytics/VideoHeartbeat.min.js
-||g2insights-cdn.azureedge.net/*/mng/g2insights.min.js
 animespirit.*###CollapsiblePanel_Statistics
-||weather.com/weather/assets/omniture-visitorapi.*.js
 ||weather.com/api/v*/script/dprSdkScript.js
-||weather.com/weather/assets/omniture-app-measurement.*.js
 ||dtiblog.com/hist_count.
-||amazonaws.com/*/trackpush.min.js
 ||gateway.boredpanda.com/event^
-||content.mql5.com/tr?
-||responder.wt.heise.de/resp/api/
 ||sbm.nate.com/setCookie?
 ||assiatv.com/css/stat.js
-||fresnel.vimeocdn.com/add/player-test-impression?beacon
 ||exelator.com/pixel.gif
-||api-js.mixpanel.com/engage/?
-||api-js.mixpanel.com/track/?
 ||try.abtasty.com/*.js$3p
 ||analytics.*.*/*.php
 ||notebookinfo.de/javascript/*/collector.js
-||bmw-connecteddrive.de/z.gif?x=
-||cdn.merklesearch.com/merkle_track.js
 ||abcotvs.net^*/fban_
-||z.cdn.turner.com/analytics/cnnvan/jsmd.min.js
 ||newsource-cdn-static.ns.cnn.com/prd/analytics/1.0.1/cnnvan-omniture.min.js
 setafi.com##.footer_bl-3
 ||gamejolt.com/tick/
 ||chaturbate.com/api/adblocker/
 ||evgnet.com/beacon/
-||51nongyao.net/js/analytics.js
 kanobu.ru##a[href^="https://www.liveinternet.ru/click"]
 ||a24.biz/pixel/
 ||preved.tut.by/1px.gif
@@ -20249,7 +17896,6 @@ kanobu.ru##a[href^="https://www.liveinternet.ru/click"]
 ||cdn.branch.io^$domain=underarmour.com
 ||google-analytics.com^$domain=promiflash.de,redirect=nooptext,important,image,media,frame,stylesheet,script,xhr,other
 ||csi.gstatic.com^$domain=promiflash.de,redirect=nooptext,important,image,media,frame,stylesheet,script,xhr,other
-||bilder-a.akamaihd.net/ip/js/ipdvdc/dbav.js
 ||js-agent.newrelic.com^$domain=chaturbate.com,redirect=nooptext,important,image,media,frame,stylesheet,script,xhr,other
 ||api-js.datadome.co/js/
 ||subscribe.washingtonpost.com/acquisition/views/tracking
@@ -20259,14 +17905,11 @@ kanobu.ru##a[href^="https://www.liveinternet.ru/click"]
 ||ir.ebaystatic.com/rs/c/makeebayfasterscript-src-scripts-logger-cbdc5549.js
 beauty.ua##.footer-counters
 ctvnews.ca##img[alt="comscorebeacon"]
-||s.aimg.sk/livemonitor/js/aztracker.js
 ||asadcdn.com/bt^
 ||merkur.de/_cua.html
 ||cdn.cr.org/etc/designs/electronics/clientlibs/tracking.js
 ||run.crtx.info/track.min.js
-||track.searchiq.co/api/tr?callback=*&event=
 ||yandexcdn.com/ajax.php
-||www.uz/counter/collect?
 ||fernomius.com/event/
 ||sweetshow.com/r_log.php
 ||tubepleasure.com/r_log.php
@@ -20275,13 +17918,11 @@ ctvnews.ca##img[alt="comscorebeacon"]
 ||etl-xlmc-ssl.xunlei.com/api/stat^
 ||static.metro.co.uk/rta2/
 ||metro.co.uk/wp-content/themes/metro-parent/dist/components/measurement.min.js
-||wblt.oui.sncf/prod/*/vsca.js
 ||btrace.video.qq.com/kvcollect^
 ||affirm.com/api/*/cookie_sent
 ||app.opmnstr.com/v*/geolocate/
 ||my.kapook.com/asset/js/track.js
 ||mrtg.emailpartners.net^$image,3p
-||paypalobjects.com/*/pixel.gif
 ||usenetoffer.download/metrika^
 ||iboysoft.com/js/track.js
 ||beam.remp.nv.ua^
@@ -20289,7 +17930,6 @@ ctvnews.ca##img[alt="comscorebeacon"]
 ||static-skin.ru/assets/js/tracking-frame.min.js
 ||static.spankbang.com/static_desktop/gen/*-ai-with-privacy.js
 ||rezka.ag/setinfo/
-||strm.yandex.ru/log?
 ||pitomec.ru/top.gif
 ||cdn.gamer-network.net/*/scripts/mormont
 ||crowdtwist.com/trck/
@@ -20306,34 +17946,24 @@ jaiefra.com###Stats10_content
 ||api.mindbox.ru/scripts/*/tracker.js
 dokonline.com###Counters
 dokonline.com###Counters + div[class="block"]
-||aip-cdn.sozcu.com.tr/aip/analytics.min.js
 ||media2.newsobserver.com/newsobserver/products/escenic
 ||cewe.de/tracking/*.js
-||analytics.supplyframe.com/trackingservlet/impression?
 ||welt.de/assets/resources/webtrekk^
 ||movie2.kinoche.ru/iframe.js?id=$3p
 ||articles2.marketrealist.com/aptrk^
-||addthisedge.com/live/boost/*/_ate.track
 ||sheego.de/request/pvp.php
 ||yastatic.net/s3/distribution/yanalytics/yanalytics.js
 ||c0.froala.com/i?
 ||streamlava.cc/stats^
 ||pjstat.com^$3p
 ||rtb.loopa.net.au^$domain=junkmail.co.za
-||imp.snapdeal.biz/pub/imp?$domain=snapdeal.com
-||airunit.taobao.com/tracker.*.gif^
 ||bestbuy.com/*/analytics-*/
-||assets.bbystatic.com/analytics-dotcom/
 ||shopclues.com/assets/js/sc_tracker.js
 ||shopclues.com/assets/js/slick.js
-||cnn.com/optimizelyjs/*.js
 ||peach-static.ebu.io/pipe-*.min.js
-||sp.cargurus.com/i?stm=
 ||cisnet.iqsn.de/L*/counter-cisstart.php
 ||steamprices.com/analytics^
 ||banggood.com/statistics.html
-||s.kk-resources.com/ks.js
-||s.kelkoogroup.net/st?
 ||vivaldi.*/rep/rep.js
 ||app.call-tracking.by/scripts/calltracking.js
 ||techstage.de/ivw-bin/ivw/CP^
@@ -20355,16 +17985,11 @@ kinotan.ru##.counts
 ||app.huawei.com/hwa-c/configresource/js/general/ha.js
 ||app.huawei.com/hwa-c*&action=
 ||toptracker.ru/buttons/counter.gif
-||d2c7xlmseob604.cloudfront.net/tracker.min.js
 reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##a[href="#pixel"]
 ||heyhelga.net/analytics.js
-||analytics-cms.whitebeard.me/js/
-||bol.com/tracking/*.gif
-||voonik.com/analytics.min.js
 ||topshop.com/wcsstore/ConsumerDirectStorefrontAssetStore/images/trans_pixel.gif
 tap.az##.links-sites > .counters
 ||freepornq.com/counter/
-||analdin.com/js/analytics.js
 ||tracking.pinflix.com/static/smt.js
 ||api.radio.*/info/*/user/log?event
 ||melonstube.com/js/analytics
@@ -20377,31 +18002,23 @@ tap.az##.links-sites > .counters
 ||webtv.bundestag.de/iptv/js/youbora^
 .ru/stat/?c=$domain=ucoz.net
 levashove.ru##.footer-four > section#custom_html-5
-||d1gofkrkum4ehe.cloudfront.net/tracker.js
-||graph.instagram.com/logging_client_events
 ||vc.ru/hit^
-||tracker.departapp.com/api/collect?
-||open.spotify.com/log/analytics
 ||amazon.de/gp/uedata*adblk
 ||userzoom.com/uz.js$3p
 ||wieistmeineip.de/ip-adresse/$3p
 ||7days.ru/statistics/*/hit?id=
 ||reklama.lv/services/collect.php
 ||corebipublic.blob.core.windows.net/*/corebi.event.js
-||medium.com/_/stat?event=pixel.load
 ||glami.com.tr/js/compiled/pt.js
 ||blogheim.at/ranking
 ||watch32hd.org/tracking
 ||watch32hd.org/adblock
 ferra.ru##div[data-widget="plista_widget_belowArticle_desktop_nocss"]+div[class^="_"] > svg
 ferra.ru##div[data-widget="plista_widget_webApp_mobile_nocss"]+div[class^="_"] > svg
-||static-cl.xhcdn.com/js/track.min.js
-||tagm.tchibo.de/ai.aspx
 ||onesignal.com/webPushAnalytics
 tensaigakkou.ru###custom_html-16
 ||at.rtb-cdn.net/?t_aid
 ||optimizely.com/js/geo2.js
-||d3jaymjyiads5d.cloudfront.net/tracker.js
 ||admin.blog.fc2.com/dctanalyzer.php
 ||saccest.com/js/lidyana.js
 ||avtoradio.ru/design/images/site-design/top100.gif
@@ -20411,32 +18028,22 @@ tensaigakkou.ru###custom_html-16
 ||hagebau.de/tracking^
 ||rushlane.com/*/ga-*.js
 ||imwalking.de/servlet/LandmarkServlet?clientId
-||static1.dmcdn.net/js/cpe/cpeEventTracking.min.js
 ||kerch.fm/templates/FM/js/analytic.js
 ||static.canal-plus.net/*/trcking.min.js
 ||d2-apps.net/*/impressions/log
-||businesswire.com/js/videojs.ga.min.js
 ||organicfruitapps.com/analytics
-||cdn.d2-apps.net/js/tr.js
 ||sumo.com/apps/heatmaps/
 ||sumo.com/api/event/
-||rumble.com/l/$image
-||extremetech.com/sbs/beacon.js
 ||myfonts.net/count
-||youboranqs01.com/ping
 ||news.de/empty.txt
 ||ue.nordbayern.de/cre-*/tracking^
-/bcommon/js/trckUtil.min.js$domain=buffed.de|gamesaktuell.de|videogameszone.de|gamezone.de|pcgames.de|pcgameshardware.de
 ||secure.agoda.com/pixel.gif
-||agoda.com/api/pixel/index?
-||d1d3jupgwm7m5r.cloudfront.net/prod/cloudfrontVideoTracker.
 ||juicebeard.prod.tda.link/rec/*/tracking^
 ||track.tagesanzeiger.ch/cre*/static/tracking^
 ||injapan.com/rest/*/track?*&callback=
 ||youlead.pl/track?
 ||api.code.com.tr/analytics
 ||smp.sankei.co.jp/js/analytics^
-||tms.marriott.com/error/e.gif
 ||kodik.cc/stats
 ||cdn.ustatik.com/vendor/metrica/watch.js
 ||rp-online.de/cre*/tracking^
@@ -20449,22 +18056,15 @@ tensaigakkou.ru###custom_html-16
 ||sonar.semantiqo.com^$3p
 ||manychat.com/widget/log?
 ||glssp.net/logger.js
-||d.line-cdn.net/*/torimochi.js/*/torimochi.js
-||d.line-scdn.net/*/torimochi.js/*/torimochi.js
 /counter?$domain=amazon.com|amazon.de|amazon.it|amazon.com.tr
 ||medyaradar.com/Tools/AddHit.aspx?
 ||static.gazeta.pl/info/http/xgemius-min.jsgz
 ||validate.onecount.net/js/v_sb.js
 ||validate.onecount.net/onecount/automation/a.php?__cuuid=
-||nakanohito.jp/b*/b*.js
-||nakanohito.jp/*/?uisv=
 continentseven.com##.gaoop
 ||contx.net/ingest/res/i/tag/trk
-||cdn.contx.net/collect.js
 ||contx.net/ingest/res/i/collect
 ||practicequiz.com/responsive/js/ga.js
-||omt.shinobi.jp/pv^
-||omt.shinobi.jp/tsumugi?location=
 ||t.blog.livedoor.jp/u.js
 ||e-kuzbass.ru/rank$3p
 ||pr-cy.net/image.php^$3p
@@ -20480,7 +18080,6 @@ continentseven.com##.gaoop
 ||yvesrocher.com.tr/images/avenseo/tr_TR/avenseo-uniq.min.js
 ||yvesrocher.com.tr/images/js/coremetrics.js
 ||yvesrocher.com.tr/images/js/tracking^
-||yvesrocher.com.tr/images/__utm.gif^
 ||teenporn.ws/zaq/cron.php
 ||news.nate.com/js/today/userAgent
 ||map.naver.com/*/api/searchAddressById
@@ -20490,26 +18089,19 @@ continentseven.com##.gaoop
 ||s1.daumcdn.net/svc/original/U03/cssjs/userAgent
 ||tv.naver.com/resources/release/js_*/player*Logge
 ||ssl.pstatic.net/img.tvcast/pc/js/wcslog
-||videostats.kakao.com/log^
 ||t1.daumcdn.net/language/cssjs/*/js/lib/userAgent
-||sirporno.xxx/js/analytics.js
 ||api.ip.sb/geoip$3p
 ||tlctv.com.tr/ajax/item/hitImage?
 ||tlctv.com.tr/assets/default/images/pixel.gif
 ||soundcloud.com/v*/events
 ||static-cf.afreecatv.com/asset/service/common/common_analysis.js
-||araskargo.com.tr/tr/jv_google_analytics.js
 ||cars.com/ajax/activityloggingapi^
-||ref.dealerinspire.com/visit/*/events^
 ||hsbcglobalcmb.sc.omtrdc.net/id?$redirect=nooptext,important,domain=business.hsbc.uk,image,media,frame,stylesheet,script,xhr,other
 ||dpm.demdex.net/id$redirect=nooptext,important,domain=bt.com|nhl.com|business.hsbc.uk,image,media,frame,stylesheet,script,xhr,other
-||pix.spot.im/api/*/pixel
 ||finn.no/clientstats.html
 ||finn.no/ec/REK^
 ||iha.com.tr/track.php^
 ||tag.aumago.com^$3p,script
-||trustaffs.com/api_ip_info.php?
-||cpx.golem.de/cpx.php
 ||as.1und1.de/ias/track^
 ||api.salesmachine.io/*/track/event
 ||cdn.lmiutil.com/lpassets/track-
@@ -20523,22 +18115,15 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||ie8eamus.com/fp?uuid=$domain=avgle.com
 ||p.adsymptotic.com/d/px^$domain=boudja.com
 ||fembed.com/api/ping/
-||fembed.com/r/collect?
 ||webcamsbabe.com/js/s.js
 ||01net.com/e3/nrtv/?u=
 ||cdn.daenischesbettenlager.de/analytics.js
 ||salesreps.io/shopify.js^$3p
 ||scripts.hepsiburada.net/assets/analytics/analytics.*.js
 ||airbnb.*/tracking/
-||googleadservices.com/pagead/conversion_async.js
-||analytics.twitter.com/i/adsct?
-||t.co/i/adsct?
-||linkedin.com/*/rum-track?
-||media.licdn.com/cdo/rum/id?
 ||sendsay.ru/js/target/tracking.js
 ||trtarsiv.com/js/Player/jwTracking.js
 ||histats.com^$domain=avgle.com
-||google-analytics.com^$domain=avgle.com
 ||business-key.com/top/$3p
 ||bs.yandex.ru/informer/$3p
 ||bloombergbusiness.com/horizon/track
@@ -20547,9 +18132,7 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||bemobile.ua/bug/
 ||bemobile.ua/cm/
 ||bemobile.ua/id/
-||bemobile.ua/pagestat/
 ||bemobile.ua/vplayer/
-||ati-host.net/hit.xiti?s=
 ||antivirus-alarm.ru/proverka$3p
 ||58.205.218.4/pos?act=
 ||2ip.ru/sbar/$3p
@@ -20570,7 +18153,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||d1izbwxtc3f9ue.cloudfront.net/?tid=
 ||d2d5uvkqie1lr5.cloudfront.net^*/analytics-
 ||d2d5uvkqie1lr5.cloudfront.net^*/analytics.
-||d27s92d8z1yatv.cloudfront.net/js/jquery.jw.analitycs.js
 ||criteo.com/event?$3p
 ||condenastdigital.com/track$3p
 ||cnt.re/cnt/$3p
@@ -20582,7 +18164,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||graph.facebook.com/logging_client_events
 ||goto.kz/img.php^$3p
 ||googlesyndication.com/safeframe/$3p
-||goodbookbook.com/_.gif?_
 ||front.sspicy.ru/collect?$3p
 ||findme.ru/Counter$3p
 ||eu.angsrvr.com/count
@@ -20591,7 +18172,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||ebay.com/op/t.do?event
 ||kerch.net/counter/
 ||json.inf.mtml.ru/?*&count=
-||irs01.com/irt?_iwt_id=
 ||ip-whois.net/test-speed-internet/$3p
 ||ip-jobs.staff-base.spb.ru/ip.cgi
 ||ioam.de/?
@@ -20626,7 +18206,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||prlog.ru/images/counter/$3p
 ||quantserve.com^*.swf?$3p
 ||quantserve.com^*^a=$3p
-||quantserve.com/api/
 ||quantserve.com/pixel$3p
 ||qoo.by/counter.js$3p
 ||researchnow.com/t/beacon$3p
@@ -20639,7 +18218,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||sunhome.ru/counter.php$3p
 ||sumome.com/api/event/?
 ||sumome.com/api/load/
-||sumome.com/apps/contentanalytics/
 ||sumome.com/apps/heatmaps/
 ||svadba.net.ru/counter$3p
 ||syslab.ru/cnt/$3p
@@ -20666,7 +18244,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||ucoz.kz/stat/
 ||ucoz.net/stat/
 ||ucoz.ru/stat/
-||vortex.data.microsoft.com/collect
 ||webtalking.ru/counter/$3p
 ||womentop.ru/top$3p
 ||wpdigital.net/metrics/
@@ -20678,11 +18255,9 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||yandex.ru/cycounter$3p
 ||xsltcache.alexa.com/site_stats/$3p
 ||ncp-e.com/typo3conf/ext/leadlab/res/wm_autotrack_v*.js
-||om.lds.org/id*AnalyticsFields
 ||trendyol.com/Resources/Scripts/Libs/EventCollector/eventcollector
 ||trendyol.com/__gc.gif?
 ||pi.pardot.com/analytics
-||ev.kck.st/web/track
 ||solvay.com/js/ext.js
 ||digital-dwh.dumont.de/custom/*ts_unix=*keywords=*metric
 ||baur.de/servlet/*?clientId=*&landmark=*&ssid=
@@ -20699,32 +18274,16 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||empa.flixbus.de/acv^
 ||pipe.flixbus.com/*/wt?src=pipe
 ||sp.fanatical.com/i?cd_c=*&aid=
-||jssdk.pulse.schibsted.com/autoTracker.min.js
-||collector.leaddyno.com/clickstream^
-||faz.net/l.gif?
-||corriereobjects.it/*/js/tracking/
-||gazzettaobjects.it/*/js/tracking/
-||stadvtools.akamaized.net/trackingservice/
 ||tvn.pl/sweqevub.js
-||iwa.iplsc.com/sweqevub.js
 ||daib.pl/sweqevub.js
-||interia.pl/*/hit.t?
 ||x.interia.pl/inpl/inpl.klmcounter.*.js
-||iwa.iplsc.com/iwa.js
 ||l.iplsc.com/logger/
-||events.onet.pl/v*/?_ac=kropka-
 ||rtbcx.jp.canon.com/bcx/ap/$image
 ||global.canon/00cmn/js/en/analytics.js
 ||bemail.it/audiens.php?
-||fcmatch.youtube.com/pixel
-||fcmatch.google.com/pixel
 ||sayyar.mynet.com/api/hit/
 ||citybeat.de/include/cbtrck.104.min.js
-||cnt.wetteronline.de/cgi-bin/ivw/CP/
-||tr.computeruniverse.net/*/hm?p=
-||lidl.media01.eu/tm_js.aspx?trackid=
 ||inspij.org/stats^
-||domatv.dnevnik.hr/bin/usrtrck-new.php
 ||giga.de/api/core/tracking/
 ||s.7tv.de/webtrekk/*/webtrekk_*.min.js
 ||fulltrannytube.com/stats.gif
@@ -20736,8 +18295,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||tubedupe.com/js/td_track.js
 ||wscatalog.ru/dizain/cycounter.gif
 ||cjs-cdkeys.com/index.php?action=track
-||ai.idg.se/us01^
-||ax.idg.se/st01^
 ||matelso.de/webtracking/
 ||nvworld.ru/js/ym-*.js
 ||nvworld.ru/js/ua-*.js
@@ -20747,7 +18304,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||kino.de/api/core/tracking^
 ||sportdeutschland.vidibuscloud.net/themes/sportdeutschland*/javascripts/webtrekk.js
 ||boss.berlinonline.de/cp.php
-||d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js
 ||classic.comunio.de/external/ct^
 ||tvigle.ru/track/
 ||reisen.de/usertracking^
@@ -20759,38 +18315,28 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||zalando.de/api/rr^
 ||api.centify.co/adb
 ||haber365.com/hit?i=
-||rover.ebay.*/roversync/?site=$image
-||rover.ebay.*/roverimp/*&trknvp=$image
-||rover.ebay.*/roverclk/*?trknvp=$image
 ||t.oned.io/onedio-longvisit.img?_t=
 ||amplify.outbrain.com/cp/obtp.js
-||cmap.alibaba.com/ml.html?callback=landing
 ||site.cdnmaster.cn/sitemaster/collect.js
-||assets.shop.hisense.com/ta.js
 ||alternate.de/js/track.js
 ||camwhores.tv/*action=js_stats
 ||amazonaws.com/reachpeople^
 ||aflt.market.yandex.ru/widgets/metrika
 ||timeturk.com/sayac^
-||media.myguide-cdn.com/common/analytics.js
 ||api.opinary.com/*events
 ||distributor.streamroot.io/klara/traffic/usage
 ||videoszoofiliahd.com/wp-content/themes/vz/js/ga.js
 ||altin.in/ajax.asp?i=adblock
 ||cdn.hivps.xyz/analytics-
-||imobie.com/js/analytics.js
 ||ablaze-class.space/stats
 ||alive-airport.space/advert
 ||api.socialmart.ru/analytics.php
 ||jwpltx.com/*/ping.gif
-||hukuki.net/analyticsjs.js
 ||pandanetwork.club/le/in.php^$3p
-||medicalnewstoday.com/structure/javascript/cache/beacon.js
 ||trendmd.com/events
 ||salesmanago.pl/api/r.gif
 ||utrack.buybox.click/analytics.js
 ||utrack.buybox.click/bb4shop.js
-||istanbul.com/ui/js/analytics.js
 ||turkcell.com.tr/static_lib/assets/scripts/turkcell/google-analytics^
 ||mod.calltouch.ru/callback_event.php?*&analyticsId=
 ||iqiyi.com/pixel
@@ -20798,9 +18344,7 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||winfuture.de/ajax/pixel^
 ||api.contentpass.net/stats^
 ||cpazapi.chip.de/stats^
-||popfilmeshd.net/wp-content/plugins/google-analytics-dashboard-for-wp/front/js/tracking-analytics-events.js
 ||tom.itv.com/itv/count/*
-||cpt.itv.com/*/event
 ||destyy.com/bundles/*/tracking
 msn.com##.trc_related_container
 ||elmir.ua/response/stats.php
@@ -20815,18 +18359,15 @@ msn.com##.trc_related_container
 ||prosecrets.pro/js/VietXfAdvStats/frontend.js
 msn.com##.tbla
 ||basaru.net.ru/js/coin32.js
-||adultvideotop.com/js/ga.js
 ||assets.htvapps.com/lumiere/fallback/analytics.js
 ||emag.ru/counter/counter.php?url=
 ||rt.chip.de/collect
 ||eventcom.api.np.km.playstation.net/event^
 ||kocaeligazetesi.com.tr/stats/
 ||gazetevatan.com/d/generic-counter.asp^
-||gazetevatan.com/d/j/analytics.min.js
 ||quoka.de/services/count.php
 ||milligazete.com.tr/stats^
 ||api.nova.pub/track.php^
-||frontend-prod.healthline.com/api/metrics
 ||beinsports.com/hitcountservice^
 ||indianpornvideotube.com/incnt
 dizibey.com##.sidebar > #text-19
@@ -20840,11 +18381,8 @@ dizibey.com##.sidebar > #text-19
 ||t24.com.tr/api/json/activity.php
 ||livinglanguage.com/js/View.Analytics.
 ||livinglanguage.com/content/_ui/js/View.Analytics.Controller.min.js
-||biznesinfo.az/Scripts/fingerprint.min.js
 ||vvvvid.it/vvvvid/video/*/event
 ||google-analtyics.com/analytics.js
-||api.jetlore.com/track.png?
-||dz7cp6bdqjjn5.cloudfront.net/q/s/stats/init.min.js
 ||tagsd.com/newServing/tracking_id.php^
 ||redirector.yarbot.host/jwplayer/ping.gif^
 ||dawanda.com/trck^
@@ -20876,22 +18414,17 @@ dizibey.com##.sidebar > #text-19
 ||morhipo.com/Shared/AnalyticsJS^
 /css/stat.js$domain=assia.*|assia4.com
 /css/analytics.js$domain=assia.*|assia4.com
-||svcs.ebay.com/delstats/imp/rtm
 ||ebay.*/beacon/
-||decathlon.de/content/js/tc_analytics.js
 ||stayfriends.de/mobilemember/js/framework/sf_tracking.js
 ||en2.elvenar.com/game/tracking
 ||moviepilot.de/assets/autotrack
 ||hdmz.co/site/user_geo
 ||data.shopgate.com/tracking/shopgate-analytics-sdk.production.min.js
 ||bildderfrau.de/stats/
-||oas.monster.com/Scripts/oas_analytics.js
 ||logs.jobs.com/impression_trackingv*.min.js
 ||webstats.thesoul-publishing.com/track/ws.gif
 ||boersennews.de/js/lib/BnPageTracker.js
-||pornozot.com/js/tracker.min.js
 ||bilder-a.akamaihd.net/rtl-v*/components/tracking/js/tc.min.js
-||cdn.milffox.com/static/milffox.com/js/gtm.js
 ||7.p.tdf.ringier.ch/rp.js
 ||manager-magazin.de/static/sys/pixel.gif
 ||count.manager-magazin.de/nm_trck.gif
@@ -20904,9 +18437,6 @@ dizibey.com##.sidebar > #text-19
 ||static.vdmximg.com/wp-includes/js/u_hits_control.js
 ||embed.videosdemadurasx.com/js/u_hits_control.js
 ||jsengine.ru/geoproxy/ip
-||event.api.drift.com/track^
-||rs.maxiporn.com/js/iframe-tracker.js
-||rd.com/wp-content/plugins/rd-audience-science-pixel/js/as-tracking-pixel.js
 ||rd.com/wp-content/plugins/rd-parsely-multisite/js/dynamic-tracker.js
 ||168logger.com/*/log/event?$3p
 ||t-online.de/px.js
@@ -20914,41 +18444,31 @@ dizibey.com##.sidebar > #text-19
 ||star.com.tr/xanalytic/count.asp
 ||tracking.wisepops.com^$3p
 ||static.stylight.net/js_external/trackjs.*.js
-||stats-bq.stylight.net/track/
 ||pejnya.net/counter/
 ||br.de/doTrack
 ||app.intercom.io/gtm_tracking/
 ||q.quora.com/_/*/pixel?
-||track.cedsdigital.it/track_views.php
 ||utils.cedsdigital.it/js/webtrekk.js
 ||hudb.pl^$3p
 utorrent.games,borfilm.com,hronika.info##.count
 ||mail.ru/share_count?
 ||medya.ilan.gov.tr/widgets/assets/widget/analytics.js
 ||papoto.com/api*/network/stats
-||medya.ilan.gov.tr/widgets/assets/analytics.js
 ||arc.msn.com/*/Impression?PID=
 ||199.19.203.46/js
-||jimdo.com/app/tracking/common/index/
 ||gutefrage.net/px.js
-||turbobit.net/ajax/fdlogger/
 ||morgenpost.de/resources/*/js/webtrekk
 ||kotaku.com/stats/beacon?
 ||immobilien-zeitung.de/backend/commons/js/analytics_config.js
 ||anapixel.elmundo.es/ter.gif
 ||pixelcounter.marca.com/pixelcontabilizacion/pixelcontabilizacion.gif
 ||poznamka.ru/ametrix.js
-||gamesgames.com/wdg/tracking-active
-||gamesgames.com/wdg/performance_tracker-active
 ||vidmoly.me/suba.php
 ||vidmoly.me/log.php
 ||vidmoly.me/dl.php
 ||sa.sayaclar.com/c/s*.php?$3p
 ||faz.net/placingservice/count
-||cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
-||cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js
 ||newserv.xyz^$3p
-||tagesschau.de/resources/framework/js/sitestat.js
 ||wiwo.de/js/*/webtrekk
 ||welt.de/webtrekk/
 ||lvz.de/viewlog_receiver.php?
@@ -20961,7 +18481,6 @@ utorrent.games,borfilm.com,hronika.info##.count
 ||stats.pcsg-server.de/js/
 ||russian.rt.com/nbc/|
 animeyt.tv##.ed-item > ul#filtro-letra-nuevo+div.bloque.bloque__descargas-centro.ed-container
-||cdn.taboola.com/libtrc/animeyttv/loader.js
 ||koronapay.com/*/metrika_rus.js
 ||t.lolalytics.com/?a=
 ixbt.com##.block__recommend
@@ -20972,14 +18491,11 @@ unilad.co.uk###sidebar > #text-64 > .block-title
 ||infranken.de/_fWS/json/Statistic
 ||infranken.de/fileadmin/scripts/tracking
 ||stadtbibliothek-rostock.de/weblication/grid5/gui/scripts/wClickLogger.js
-||kindernetz.de/static/tracking/xtclicks.js
 ||mtvema.com/media/module/ENT_Reporting
 ||newsmalta.com/?wordfence_logHuman
 ||lib.onet.pl/s.csr/adp
-||vice-web-statics-cdn.vice.com/fonts/mtiFontTrackingCode.js
 ||vonzeitzuzeit.de/tracking
 ||track.bazonline.ch^
-||diepresse.com/js/xtclicks.js
 ||diepresse.com/layout/diepresse/services/proxy/share-counter.jsp
 ||api.contentpass.net/analytics
 mp3.run.az###lsidebar > .mpblok:last-child
@@ -20990,15 +18506,12 @@ mp3.run.az###lsidebar > .mpblok:last-child
 ||abendblatt.de/stats
 ||online.hentai-share.me/templates/anime-share2/js/metrika.js
 ||online.hentai-share.me/templates/anime-share2/js/liveinternet.js
-||news.cn/webdig.js
 ||iphonesoft.fr/js/analytics
-||staticwl.bkmcdn.com/scripts/adwords-tracker.js
 uniongang.net##a[href^="http://whos.amung.us/stats/"]
 artmoney.ru##a[href^="http://top.list.ru/"]
 artmoney.ru##a[href^="http://www.one.ru"]
 computerbild.de##.articleAdditional > .mehrthema
 ||xtraffstat.com/js/ktr.js
-||patreon.com/api/tracking^
 /index/ping^$domain=xervoo.net|usfinf.net|darenjarvis.pro|download.cracksurl.com|hurirk.net|zeybui.net|regecish.net|onizatop.net|aporasal.net|chinnica.net|encurtador.mineiroloko.co|atharori.net|meriabub.net|gdanstum.net|fiaharam.net|underhentai.net|gatustox.net|scuseami.net|gusimp.net|cowner.net|xterca.net|gloyah.net|uclaut.net|atabencot.net|thouth.net|cinebo.net|baymaleti.net|briskgram.net|ad.bdcraft.net|swiftviz.net|ad.sapixmedia.com|activetect.net|brightvar.bid|clearload.bid|restorecosm.bid|bee.anime-loads.org|threadsphere.bid|queuecosm.bid|yoitect.com|skamaker.com|adf.ly|ay.gy|cracksurl.com|tinyium.com|skamason.com|redir2.auto-login-xxx.com|dl.underclassblog.com|special.picons.eu|quainator.com|yoalizer.com|kibuilder.com|kimechanic.com|zo.ee|tinyical.com|mmoity.com|simizer.com|coginator.com|cogismith.com|yobuilder.com|eloism.net|magybu.net|ujootchu.net|neexulro.net
 /callback/*$domain=xervoo.net|usfinf.net|darenjarvis.pro|download.cracksurl.com|hurirk.net|zeybui.net|regecish.net|onizatop.net|aporasal.net|chinnica.net|encurtador.mineiroloko.co|atharori.net|meriabub.net|gdanstum.net|fiaharam.net|underhentai.net|gatustox.net|scuseami.net|gusimp.net|cowner.net|xterca.net|gloyah.net|uclaut.net|atabencot.net|thouth.net|cinebo.net|baymaleti.net|briskgram.net|ad.bdcraft.net|swiftviz.net|ad.sapixmedia.com|activetect.net|brightvar.bid|clearload.bid|restorecosm.bid|bee.anime-loads.org|threadsphere.bid|queuecosm.bid|yoitect.com|skamaker.com|adf.ly|ay.gy|cracksurl.com|tinyium.com|skamason.com|redir2.auto-login-xxx.com|dl.underclassblog.com|special.picons.eu|quainator.com|yoalizer.com|kibuilder.com|kimechanic.com|zo.ee|tinyical.com|mmoity.com|simizer.com|coginator.com|cogismith.com|yobuilder.com|eloism.net|magybu.net|ujootchu.net|neexulro.net
 ||tracking-opi.fonpit.de/tracking/
@@ -21010,23 +18523,15 @@ m.lenta.ru##.b-footer_counters
 ||googletagservices.com/tag/js/gpt.js$domain=sinoptik.ua|gutefrage.net|dt.ua|ngs.ru|unian.net|easybib.com|bohenon.com|linuxtopia.org|newsroom.kh.ua|hclips.com|noticierodigital.com|northumberlandgazette.co.uk|mywebtimes.com|watchuseek.com|telekritika.ua|fontanka.ru|vesti.ua|bhub.com.ua|guhoyas.com|rst.ua|hh.ru|buhgalter.com.ua|unocero.com|autonews.com|metropoles.com|okezone.com|m.yeniakit.com.tr|kanalukraina.tv|day.az|knuddels.de
 ||imagecrest.com/asset/view/stats.php
 ||uaswitcher.org/logic/page/data
-||success.trendmicro.com/jslibrary/*/NetworkTracking.js
-||fonts.net/t/trackingCode.js
 ||vkcache.com/js/amung_counter.js
-||va.tawk.to/log^
 ||inputs.alooma.com/track^
-||syl.ru/misc/js/global/tracker.js
 ||sitejabber.com/set-fingerprint/
 ||spinmedia.com/clarity.min.js
 ||spinmediacdn.com/clarity.min.js
 ||dove.com*/Assets/JS/udm.js
-||cdn.ampproject.org/*/amp-analytics-
-||log.ventunotech.com^*/beacon.gif?
-||venlog-1542946650.us-west-2.elb.amazonaws.com^*/beacon.gif?
 ||vkcache.com/js/video.*counter*.js
 ||vidoza.net/papi/*/addevent/promo_data
 ||daxab.com/logger^
-||sueddeutsche.de/statistics?eventType=
 maxpark.com###listOfCounters
 ||static.plista.com/async.js$3p
 ||haber7.com/ad-ipmression-pixel/
@@ -21037,11 +18542,8 @@ maxpark.com###listOfCounters
 ||kazus.ru/js/*/log_trackjs.htm
 ||privacy.www.nu.nl/pixel^
 ||static-*.plista.com/async.js$3p
-||trivago.*/log?sLog=
-||tracking.tidalhifi.com/wimp/tracking/
 ||tidal.com/t|
 westnews.com.ua##a[href="http://www.bigmir.net/"]
-||d17m68fovwmgxj.cloudfront.net/js/appier-track-
 ||alteregoru.ru/js/counter
 /g00/*/TU9SRVBIRVVTOCRodHRwOi8vY3AtaW4ubmFub3Zpc29yLmlvL2NsaWVudHByb2ZpbGVyL2FkYj9pMTBjLm1hcmsuc2NyaXB0LnR5cGU%3D_$1p
 ||mallorcamagazin.com/sfCounter
@@ -21049,14 +18551,11 @@ westnews.com.ua##a[href="http://www.bigmir.net/"]
 ||dba.dk/ajax/tracking
 ||dbastatic.dk/Content_uex/scripts/tracking
 ||pes.itv.com/*/post/
-||hrs.de/bi/null.gif?
-||blogtotal.de/blogtotal_stats_
 ||2app.lk/events.gif^
 ||a.check24.net/misc/click.php?
 ||ras.reise.s.idealo.de/visit|
 ||ivw.mairdumont.com/get?referrer=
 ||dr.dk/drWebStat/
-||playentry.org/js/analytics.js
 ||dr.dk/mu-online/api/*/reporting/
 ||storeedgefd.dsx.mp.microsoft.com/*/oemdiscovery?
 ||playout.3qsdn.com/watchtime?event=
@@ -21065,18 +18564,13 @@ westnews.com.ua##a[href="http://www.bigmir.net/"]
 ||schlaubi.de/dynamicjavascript/tracking^
 ://datalayer-*.sky.com^$domain=sky.com
 ||news.de/track.php^
-||akamaihd.net/worldwide_analytics/tagcommander/
 ||static.cotemaison.fr/min/js/consent
 ||static.cotemaison.fr/min/js/request_tracker
-||static.cotemaison.fr/min/js/tagcommander_
 ||raidlight.com/*/index.php?controller=statistics
 ||fiylo.de/typo3conf/ext/of_design/Resources/Public/JavaScript/Libs/smarttag_LIVE.js
 ||steampowered.com/default/usabilitytracking
-||report.23video.com/api/analytics/
 ||mb.mtvnservices.com/data/collect/
 ||slideplayer.biz.tr/slide/getviewscount/
-||hh.ru/stat?url=
-||facebook.com/tr/|
 ||kickass.cd/analyze*.js
 ||kickass.immunicity.gold/analyze*.js
 ||xing.com/collect/
@@ -21096,7 +18590,6 @@ reuters.com###taboola-recirc
 ||groupon.it/tracky|
 ||api.netmera.com/event^
 ||addefend-platform.com/s?
-||weltsport.appspot.com/hstrck-detect.js^
 drive2.ru##.js-page > * > .dv-post-header > [class] > [class] > [id] > [class][id]
 drive2.ru##.o-columns > .o-columns__side > [class] > [class][id] > [class][id]
 drive2.ru,drive2.com##.is-tracked[data-metrika="recomm"]
@@ -21105,7 +18598,6 @@ drive2.ru,drive2.com##.js-scrolltracking[data-adkind="relap"]
 ||log.prezi.com^
 thehill.com###block-thehill-blocks-amp-outbrain
 ||cstream.wi-fi.ru/csc-event$domain=wi-fi.ru
-||gjapplog.uc.cn/collect^
 ||hqq.tv/js/gcounter.js
 ||hqq.tv/js/amung_counter.js
 ||reutersmedia.net/*/js/analytics/win-GTM.js$domain=mobile.reuters.com
@@ -21117,18 +18609,14 @@ znak.com##.relap
 ||games.softgames.de/assets/sg-ga-track-sdk.js
 ||7tv.de/service/log/
 ||ad.antventure.com/pixel
-||songmeanings.com/*/e.gif?pixels=
 ||vidoo.de/api_v*/index.php?service=stats&
 ||vidoo.de/api_v*/index.php?service=analytics&
 ||thcdn.com/*/tracking/*.js$domain=myprotein.ru|myprotein.com|myprotein.com.ua|myprotein.sk|myprotein.co.za
 ||r0.mail.ru/pixel/
 ||id.rambler.ru/login-20/counters.js
-||olympiaverlag.sc.omtrdc.net/b/ss/
 ||friends2follow.com/f2fi.php^
-||themonitor.com/shared-content/art/stats/common/tracker.js^
 ||cxo.name/collect?
 ||puhutv-static.akamaized.net/scripts/segmentify.$script
-||doublepimp.com/Scripts/Analytics/
 ||hmma.baidu.com/app.gif
 ||common.duapps.com/appLock/getConf?tk*&vendor=
 sinoptik.ua###bigmirTop
@@ -21151,7 +18639,6 @@ newslab.ru##.sharing
 washingtonpost.com##.social-tools-wrapper-bottom
 espreso.tv##.wrap-footer .counter
 vse42.ru##.ya-metrika
-/smarttag.js$domain=faz.net|heute.de|zdf.de|zdfinfo.de|zdfkultur.de|zdfneo.de|zdfsport.de
 vidak.icu,pb.wtf,piratbit.*##a[href="//www.liveinternet.ru/click"]
 hotstuff.com.ua,mobivid.net,theplanet.ws##a[href="http://mycounter.com.ua/"]
 infoorel.ru##a[href="http://www.infoorel.ru/stat/stat.php"]
@@ -21168,17 +18655,13 @@ hentaiz.org##img[width="31"][height="31"]
 artmoney.ru##noindex > a
 dreamprogs.net##td[width="88"][height="31"]
 ||3dn.ru/stat/
-||3dnews.ru/track?
 ||3sat.de/mediaplayer/*/plugins/IVWTrackingPlugin.swf
 ||3sat.de/mediathek/xmlservice/web/tracking
-||4players.de/javascript/awstats_misc_tracker.js
 ||81.176.238.128/Counter.aspx
-||aa.avvo.com/1/collect?*&events=
 ||ab-in-den-urlaub.de/TrackingPixel_
 ||ab-in-den-urlaub.de/nocacheTracking.php
 ||ab-in-den-urlaub.de/resources/cjs/tracking
 ||ab-in-den-urlaub.de/usertracking
-||accounts.ad.nl/gscounters.sendReport
 ||ace.segye.com/?cookie
 ||ace.segye.com/?uid=
 ||addthis.com/red/$script,3p
@@ -21188,19 +18671,13 @@ dreamprogs.net##td[width="88"][height="31"]
 ||adobe.com/*/s_code*.js
 ||adobedtm.com^*/satelliteLib-$script,domain=euronews.com|allrecipes.com|nvidia.at|nvidia.be|nvidia.cn|nvidia.co.jp|nvidia.co.kr|nvidia.co.uk|nvidia.com|nvidia.com.br|nvidia.com.mx|nvidia.com.tr|nvidia.com.tw|nvidia.cz|nvidia.de|nvidia.dk|nvidia.es|nvidia.fi|nvidia.fr|nvidia.in|nvidia.it|nvidia.nl|nvidia.no|nvidia.pl|nvidia.ru|nvidia.se
 ||aimp.ru/data/counter.html
-||akamai.net/*/chartbeat.js
 ||aksam.com.tr/analytic
 ||alawar.com/gcounter_alawar.js
-||amazon.com/1/batch/1/OP/
-||amazon.com/1/batch/1/OE/
-||amazon.com*/ReportEvent?
-||amazon.com*/record-impressions?
 ||amazon.com*/recordevent.html?
 ||amazon.com/*/cerberus/log/
 ||amazon.com/empty.gif?
 ||amazon.com/follow/log-metrics^
 ||amazonaws.com/pixelpop/app/pixelpop-
-||an.yandex.ru/count/
 ||analytics-static.unister-gmbh.de^
 ||analytics.unister-gmbh.de^
 ||aol.com/track/
@@ -21218,7 +18695,6 @@ dreamprogs.net##td[width="88"][height="31"]
 ||assets-jpcust.jwpsrv.com/*/ping.js
 ||at.mklaud.com/at/at_log_*.php
 ||auto-bild.de/*/gaEvents
-||auto-motor-und-sport.de/js/sophus3/logging.js
 ||autoscout24.de/ArticleList/CustomLogging
 ||autoscout24.net/unifiedtracking/analytics.js
 ||autoteile24.de/*_tracking.js
@@ -21233,15 +18709,12 @@ dreamprogs.net##td[width="88"][height="31"]
 ||bing.com/action/
 ||blick.ch/stats
 ||bomp.odmedia.net^$domain=fcb.tv
-||booking.com/js_tracking?
 ||bravotube.net/b_track.js
 ||brightcove.com/1pix.gif
 ||brille24.de/fileadmin/tracking
-||cbslocal.com^*/cbs1x1.gif?
 ||cdn-library.net/*&data=anti-abp
 ||cdn.segment.com/analytics.js
 ||cdn.static-fra.de/*/tracking/
-||cdn.theoplayer.com/t?
 ||check24.de/js/tracker.php
 ||check24.de/misc/tracking_gif.php
 ||citizensvoice.com/logger/p.gif
@@ -21249,10 +18722,8 @@ dreamprogs.net##td[width="88"][height="31"]
 ||clck.yandex.ru/counter/$domain=metro.yandex.ru
 ||cleverbridge.com/*/cleverAnalytics.js^
 ||click.xda-developers.com/api/pixel.gif
-||clickstream.grubhub.com/event.gif?event=
 ||clientlog.portal.office.com^
 ||cm.g.doubleclick.net^
-||cmap.alibaba.com/landing_ae.gif
 ||cmexota.ru/templates/default/images/livinternet.png
 ||collections.mp.microsoft.com/*/collections/query
 ||comet.yahoo.com^
@@ -21260,52 +18731,36 @@ dreamprogs.net##td[width="88"][height="31"]
 ||comvel.media/etc/designs/comvel/clientlibs/tracking
 ||core.bunchbox.co/geo.js^
 ||countess.twitch.tv^
-||cpxl.golem.de/gif
 ||cultofmac.com/presslabs.js
-||d395ev7kdef0wl.cloudfront.net/a.gif?
-||d3sbxpiag177w8.cloudfront.net/Analytics/
 ||dailymotion.com/gravity/report
-||dailymotion.com/logger/*?session_id=
 ||dailymotion.com^*/log/
 ||danawa.com/logger/
 ||dandb.com/*/pixel/?$3p
 ||dc.services.visualstudio.com/*/track
 ||dealer.com/off-platform/pix-at.min.js^
-||dec.sitefinity.com/collect/
-||demandware.edgesuite.net/*/dwanalytics.js
 ||dfiles.eu/stats.php
 ||diziler.com/ajax/item/hitImage
 ||dmcdn.net/js/gen/lib/dm/ga.js
 ||dogannet.tv/q/s/stats
 ||downloads-photoshop.ru/templates/dp/images/count.png
 ||downloads-photoshop.ru/templates/dp/images/count_top.png
-||dpool.sina.com.cn/iplookup/iplookup.php
 ||dropbox.com/destiny_log
 ||dropbox.com/el/?b=open:
 ||dropbox.com/web_timing_log
 ||dsr.livefyre.com/*/collection/
 ||dsr.livefyre.com/livecountping/
 ||dus.trivago.com/tracking
-||dws.reporting.dnitv.com/dni_reporting.js
 ||ebaystatic.com/js/v/in/roverlv.js
 ||ebaystatic.com^*/tracking_
 ||embed.sendtonews.com/player2/data_logging.php?
-||evcdn.com/store/plugins/tracker-ev-sdk.js
 ||execute-api.*.amazonaws.com/current/events?
-||expedia.*/1x1.gif?
 ||expedia.*/2x2.gif?
 ||expedia.*/minify/client-logger-bundle-
-||expedia.com/api/datacapture/track
-||expedia.com/cl/data/typeahead_client_metrics.json
 ||expedia.com/omniture.json^
 ||expedia.com^*/evaluateexperimentsandlog
 ||expedia.com^*/logexperiments
 ||extra.cz/counter.php?id=
-||facebook.com/impression.php
-||facebook.com/tr/?
-||facebook.com^*/impression_logging/
 ||facebook.com^*/logging/
-||fb.ru/misc/js/global/tracker.js
 ||feedburner.com/~r/
 ||feeds.feedburner.com/~fc/
 ||fool.com/tracking/
@@ -21333,7 +18788,6 @@ dreamprogs.net##td[width="88"][height="31"]
 ||github.com/hydro_browser_events
 ||global.sueddeutsche.de/globalassets/standalone/szstats/configuration.json
 ||go.com/b/ss/
-||google-analytics.com^*/__utm.gif
 ||google.com/apis/gpf_metrics?
 ||google.com/images/phd/gfl.gif
 ||goroost.com/api/pageview
@@ -21348,8 +18802,6 @@ dreamprogs.net##td[width="88"][height="31"]
 ||horizon.mashable.com/*/track
 ||hotel.idealo.de/report
 ||hotwire.com/api/*/logging/
-||hotwire.com/api/datacapture/track
-||hotwire.com^*/1x1.gif?
 ||hotwire.com^*/evaluateexperimentsandlog
 ||hotwirestatic.com/*/comp/gtm/googletaganalytics.js
 ||gate.hockeyapp.net/*/track
@@ -21357,17 +18809,14 @@ dreamprogs.net##td[width="88"][height="31"]
 ||i.ag.ru/ag/i/counters_new_nr.png
 ||i.computer-bild.de/i/ab/*.gif?r
 ||i.computer-bild.de/i/blind.gif
-||ibeat.indiatimes.com/js/pgtrackingV*.js
 ||idealo.com/*webtrekk
 ||idealo.net/*webtrekk
 ||images-amazon.com^*/ClientSideMetricsAUIJavascript*.js
 ||images.search.yahoo.com/viewer;_ylt=
-||imdb.com/tr/?
 ||imdb.com/twilight/?
 ||imdb.com^*/b.gif
 ||img.litix.io/a.gif
 ||infoorel.ru/count.php
-||internet-abc.de^*/eTracker.js
 ||istatistik.milliyet.com.tr/CntRpt.aspx
 ||ixbt.com/js/trg.js
 ||izlesene.com/js/site/tracker.js
@@ -21377,38 +18826,28 @@ dreamprogs.net##td[width="88"][height="31"]
 ||js.welt.de/*/webtrekk
 ||jsdelivr.net/snowplow/
 ||jwplatform.com/ping.gif?
-||karstadt.de/on/demandware.store/*/__Analytics-Tracking?
 ||kfzteile24.de/*_tracking.js
 ||kia.ru/bitrix/templates/.default/js/jquery.gatrack.dpack.js
-||kinja.com/api/analytics/
-||kotaku.com/api/analytics/
 ||krone.at/hps/data/test/md_track.php
 ||l.ivi.ru/logger/
 ||l2.io/ip.js
-||licdn.com/*li.lms-analytics/
 ||linkedin.com/emimp/
 ||livestream.com^*/analytics/
 ||log.liverail.com^
-||logger-*.vty.dailymotion.com/dm/
 ||logger.danawa.com/tracker
 ||login.yahoo.com/config/loga?pad=
 ||magnitka.biz/top/img.php?
 ||mail.kz/assets/frontend/img/counter.png
-||mail.ru/k?vk_id=$domain=vk.com
 ||mail.yahoo.com/neo/mbfb?bk=
 ||mail.yahoo.com/neo/splunkLogger
 ||maps.googleapis.com/*/stats.js
 ||marc-o-polo.media01.eu/view.aspx?trackid
 ||mc.dailymotion.com/masscast/
-||media-allrecipes.com/assets/deployables/*/analytics.bundled.js
 ||media-imdb.com/*/js/ads/beacon-
 ||media-imdb.com/images/*/imdbads/js/beacon-$script
 ||mediashop.tv/daten/*/google.js
 ||megashara.org/uploads/button/online.png
-||meinauto.de/js/vendor/criteo/criteo_ld.js
 ||meta.ua/f_new.asp?g=
-||metrics.amd.com/b/ss/
-||metrics.apple.com/b/ss/$image
 ||mimg.sportsworldi.com/Lib/google_analytics.js
 ||mm.welt.de^
 ||montblanc.lenta.ru^
@@ -21424,10 +18863,8 @@ dreamprogs.net##td[width="88"][height="31"]
 ||msn.com^*/report.js
 ||msn.com^*/track.js
 ||msnbc.msn.com^*/analytics.js
-||mtcs.nhk.or.jp/b/ss/$image
 ||n11.com/realTime/count
 ||nbcnews.com/databox/databoxservice.asmx/GetLocation$domain=nbcnews.com
-||nbcnews.com/trackingService/$domain=nbcnews.com
 ||nestle.com/staticlocal/analytics.js
 ||netflix.com/*/log|
 ||netflix.com/track/
@@ -21436,23 +18873,17 @@ dreamprogs.net##td[width="88"][height="31"]
 ||newsharecounts.com/count.json
 ||newsweek.com/www/js/mar2015/counter.js
 ||notebooksbilliger.de/*/webtrekk
-||omniture.chip.de/b/ss/
-||ophan.theguardian.com/a.gif
-||orbitz.com/api/datacapture/track
 ||orbitz.com/cl/data/bingpixels.json?
 ||orbitz.com/cl/data/typeahead_client_metrics.json
 ||orbitz.com/minify/client-logger-bundle-
-||orbitz.com^*/1x1.gif?
 ||orbitz.com^*/2x2.gif?
 ||orbitz.com^*/evaluateexperimentsandlog
 ||ostkcdn.com/js/ostk-user-tracking-*.js
 ||ostkcdn.com/js/thirdparty/siteIntercept.*.js
-||partner.rozetka.com.ua/ret_pixels/
 ||paypal.com/webapps/beaconweb/
 ||pcgames.de/webservices/socialShareCount.php
 ||pcgameshardware.de/webservices/socialShareCount.php
 ||pclick.yahoo.com^
-||pcnet.com.tr/?wordfence_logHuman=
 ||pcwelt.de/js/amazon_tracking.js
 ||permato.com/impression?
 ||pic4you.ru/img/footer.js
@@ -21467,19 +18898,16 @@ dreamprogs.net##td[width="88"][height="31"]
 ||porntube.com^*/track
 ||preis24.de/js/webtrekk.js
 ||pudra.co/counter/
-||qq.com/pingd?
 ||quartic.pl/api/event^
 ||quartic.pl/t.php^
 ||r.chip.de/images/pic.gif?
 ||r.msn.com^
 ||r1.computerbild.de/images/pic.gif
 ||ranking.fc2.com/analyze.js
-||ranking.fc2.com/count?
 ||rcs.mako.co.il/js/neo/hpstats.js
 ||rcs.mako.co.il/js/scripts/metrics.js
 ||real-user-monitoring.a.autoscout24.com^
 ||reanimator.net/informer-images/
-||recs.richrelevance.com/rrserver/tracking?
 ||reformal.ru/log.php
 ||reise.com/js/webtrekk
 ||reisen.tchibo.de/webtrekk
@@ -21491,14 +18919,10 @@ dreamprogs.net##td[width="88"][height="31"]
 ||rl0.ru/*/dist/post.js$domain=www.rambler.ru
 ||rozetka.com.ua/w/?
 ||ruslab.net/a/p.js
-||russianfood.com/js/informb_stat.core.js
 ||s.d.adup-tech.com/services/track.js
 ||s.mynet.com.tr/geolocation/geocookie.js
-||s.shopify.com/visit/record.gif?
-||s.yimg.*/cv/conversion.js^
 ||sahibinden.com/ajax/counter
 ||samsung.com/*/peppermint_buy_tracking.js
-||samsung.com^*/scripts/tracking.js
 ||scripts.sophus3.com/s3s/ams/logging.js
 ||scripts.zeit.de/static/js/webtrekk
 ||secretescapes.de/assets/common/tracker
@@ -21506,17 +18930,12 @@ dreamprogs.net##td[width="88"][height="31"]
 ||serv.tooplay.com/analyse
 ||serv2.tooplay.com/b.gif
 ||service.geico.com/insite/js/mbox2.js
-||sifomedia.sf.se/Scripts/oas_analytics.js
 ||sinst.fwdcdn.com/img/newImg/liveinternet.gif
-||slack.com/clog/track/?
 ||spaces.ru/*.gif?rnd=
-||spiegel.de/nm_trck.gif?
 ||spiegel.tv/geoip/geoip.json
 ||spieletipps.de/js/jwplayer/plugins/tracking-min.js
-||sport.be/javascripts/tracking/counterassets.js^
 ||spot.im/analytics/analytics.js
 ||spot.im/api/tracker/
-||sputniknews.com/services/counter/
 ||srv.onedio.com/geo/code
 ||srv1.srv-stat.com/*/?tid=
 ||stackoverflow.com/gps/event
@@ -21528,35 +18947,26 @@ dreamprogs.net##td[width="88"][height="31"]
 ||stats.computecmedia.de^
 ||store.nike.com/cms/analytics-store-desktop.js
 ||synapsys.us^*/tracker.js
-||t.insigit.com/assets/dct.js
-||tagesschau.de/resources/framework/js/tracking.js
 ||tags.tagcade.com/*/tagcade.js^
 ||tamgrt.com^*&pixel_version=
 ||tamindir.com/cdn-cgi/pe/bag2?r[]=
 ||tchibo.de/prof/js?event
-||theatlantic.com/assets/static/theatlantic/img/sherlock.gif?
 ||thisisacoolthing.com/fp.js^
-||tk.ilius.net/tr.gif?
 ||track.ad.nl^
 ||track.vitringez.com/tracking.js
 ||tracking.autoscout24.com^
-||traffic.outbrain.com/network/trackpxl?
 ||travel-assets.com^*/experimentrecorder
-||travelocity.com/api/datacapture/track
 ||travelocity.com/cl/data/bingpixels.json?
 ||travelocity.com/cl/data/typeahead_client_metrics.json
 ||travelocity.com/minify/exp.core.channeltracking
 ||travelocity.com/minify/exp.core.tvlytracking
-||travelocity.com^*/1x1.gif?
 ||travelocity.com^*/2x2.gif?
 ||travelocity.com^*/evaluateexperimentsandlog
 ||traveltracking.check24.de^
 ||tribl.io/h.js
-||tribl.io/firm_tracking.js
 ||tribl.io/_t.gif?
 ||tribl.io/analytics*.js^
 ||tripadvisor.*/actionrecord
-||tripadvisor.*/cookiepingback?
 ||tripadvisor.*/garecord
 ||tripadvisor.*/impressionrecord
 ||trivago.de/search/log
@@ -21595,7 +19005,6 @@ dreamprogs.net##td[width="88"][height="31"]
 ||yahoo.com/neo/stat
 ||yahoo.com/neo/ygbeacon/
 ||yahoo.com/neo/ymstat
-||yahoo.com/p.gif?
 ||yahoo.com/pageview
 ||yansk.ru/counter/
 ||yazilim.net/alexa/
@@ -21606,10 +19015,8 @@ dreamprogs.net##td[width="88"][height="31"]
 ||zara.media01.eu/tm_js.aspx?trackid
 ||zive.cz/Client.Scripts/tracking.js
 ||zonastat.com/installer.html?param=
-||ztat.net/*/adrum.js^
 ||ztat.net/*/webtrekk.min.js^
 ||google.com/log?$redirect=nooptext,image,media,frame,stylesheet,script,xhr,other
-||yandex.ru/clck/click|
 ||clck.dzen.ru/click|
 ||yandex.*/clck/
 !
@@ -21643,7 +19050,6 @@ dreamprogs.net##td[width="88"][height="31"]
 ! Tracking url of GMass email service
 link.gmapp*.net$image
 ! Start: cnet.com trackers (otherwise -- unblocked by the anti-adblock exclusion)
-||cnet.com/akam/*/pixel_$domain=cnet.com
 ||facebook.com/tr/?$domain=cnet.com,important
 ||imrworldwide.com^$domain=cnet.com,important
 ||scorecardresearch.com^$domain=cnet.com,important
@@ -21658,7 +19064,6 @@ link.gmapp*.net$image
 ||rum-static.pingdom.net/*-*.js$script,redirect=noopjs,important,domain=leboncoin.fr
 !
 ||160.16.86.134/rtools/*/r_counter.js
-||a.flux.jp/analytics.collect.v1.CollectService/
 ||adtonos.com/atr/*/px.gif
 ||assets.rpglogs.com/js/global/googleAnalytics.*.js
 ||assets-prod.sumo.prod.webservices.mozgcp.net/static/gtm-snippet.
@@ -21688,15 +19093,10 @@ link.gmapp*.net$image
 ||istoe.com.br/@nave/gateway/reply?navtrackdata=
 ||lecturas.com/Content/*/js/trackPopup.js
 ||linkedin.com/*/track|
-||list-manage.com/track/
-||ltwebstatic.com/she_dist/libs/devices/fpv2.
 ||m1tm.motor1.com/analytics.js
-||mark.isbank.com.tr/cdn/automation.js
 ||mediatrend.kr/aiDataScript.js
-||mixi.net/static/js/build/mixi-analysis.production.js
 ||mparticle.weather.com/webevents/
 ||nikaraw.com/load_adb
-||piano.io/publisher/fusion/lucid/data/
 ||plug.it/iplug/js/lib/iol/analytics/
 ||postbank.de/etc/*/clientlib-postbank-webtrekk
 ||print24.com/api/*/analytics/
@@ -21708,8 +19108,6 @@ link.gmapp*.net$image
 ||safevisit.org/api/v*/c?$redirect=nooptext
 ||sbazar.cz/*/hit|$xhr
 ||sdk.mrf.io/statics/marfeel-sdk.js
-||sentinel.defacto.com.tr/api/Tracking/
-||so-zou.jp/js/ga.js
 ||static.iris.informa.com/widgets/*/iris-t.js
 ||surfsnow.jp/common/js/analytics_
 ||sve.online.sberbank.ru/metrics/partners
@@ -21720,14 +19118,9 @@ link.gmapp*.net$image
 ||tracker.citicsinfo.com^
 ||unite.nike.com/auth/unite_session_cookies/
 ||vanilla.futurecdn.net/tvtechnology/media/shared/js/jwplayer-analytics
-||web.snrbox.com/tck/$domain=komputronik.pl
 ||windowspro.de/stats/mto.js
 ||zara.com/integration/zenit/events/hit
 ! amazon.co.jp
-||aiv-delivery.net/Events/
-||aiv-delivery.net/v1/ReportEvent
-||amazon.*/cdp/usage/Clickstream
-||amazon.*/ReportEvent
 ! jscrambler.com
 ||jscrambler.com/bc.js
 ||jscrambler.com/api/statistics
@@ -21802,7 +19195,6 @@ link.gmapp*.net$image
 ||api.setting.intl.miui.com^
 ||data.sec.intl.miui.com^
 ||log.avlyun.sec.intl.miui.com^
-||tracking.*.miui.com^
 ||metok.sys.miui.com^
 ||mazu.sec.miui.com^
 ||auth.be.sec.miui.com^
@@ -21811,7 +19203,6 @@ link.gmapp*.net$image
 ||data.sec.miui.com^
 ||logupdate.avlyun.sec.miui.com^
 ||r.browser.miui.com^
-||tracking.miui.com^
 ||xlmc.sec.miui.com^
 ||data.mistat.intl.xiaomi.com^
 ||register.xmpush.xiaomi.com^
@@ -21845,7 +19236,6 @@ link.gmapp*.net$image
 ! grafana
 ||stats.grafana.org^
 ! smotrim.ru
-||rumstat.cdnvideo.ru^
 !
 ! Swiftkey(Microsoft) Keyboard
 ||telemetry.api.swiftkey.com^
@@ -21870,7 +19260,6 @@ cdn-settings.appsflyersdk.com^
 ||appsflyer-report.honkaiimpact3.com^
 ||attr.appsflyer.com^
 ||banner.appsflyer.com^
-||cdn-settings.appsflyersdk.com^
 ||cdn.appsflyer.com^
 ||cdnappicons.appsflyer.com^
 ||conversions.appsflyer.com^
@@ -21895,7 +19284,6 @@ cdn-settings.appsflyersdk.com^
 ||track.appsflyer.com^
 ||validate.appsflyer.com^
 ||wa.appsflyer.com^
-||websdk.appsflyer.com^
 ! QQ
 ! QQ Music
 ! Relap - avoid breaking their website on desktop
@@ -21919,7 +19307,6 @@ cdn-settings.appsflyersdk.com^
 ||int.vlancaa.fun^
 ||tok.vaicore.xyz^
 !
-||logservice.hicloud.com^
 ||logger.growstarry.com^
 ||beacon-api.aliyuncs.com^
 ||adash.man.aliyuncs.com^
@@ -21930,7 +19317,6 @@ cdn-settings.appsflyersdk.com^
 ||node.aibeacon.jp^
 ||metrics.plaid.com^
 ||mon*-platform-*.tiktokv.com^
-||log*-applog-*.tiktokv.com^
 ||logservice-*.platform.dbankcloud.cn^
 ||ubacollect-*.cloud.dbankcloud.cn^
 ||datacollector-*.dt.dbankcloud.cn^
@@ -21944,7 +19330,6 @@ cdn-settings.appsflyersdk.com^
 ||onthe.io^
 ||t.adx.opera.com^
 ||sensors.snaptube.app^
-||analytics.kongregate.io^
 -spiky.clevertap-prod.com^
 ||logs.gshopper.com^
 ||airlytics.airlock.twcmobile.weather.com^
@@ -21961,7 +19346,6 @@ cdn-settings.appsflyersdk.com^
 ||log-v4-insight.kaizenplatform.net^
 ||tracker.neodatagroup.com^
 ||stats.sxp.smartclip.net^
-||static.fengkongcloud.com^
 ||fp-*it*.fengkongcloud.com^
 ||cloudconf.fengkongcloud.com^
 ||tracker.fengkongcloud.com^
@@ -22045,7 +19429,6 @@ cdn-settings.appsflyersdk.com^
 ||analytics.300624.com^
 ||toblog.ctobsnssdk.com^
 ||tobapplog.ctobsnssdk.com^
-||bs.nakanohito.jp^
 ||tag.karte.io^
 ||alogsus.umeng.com^
 ||log1.happymod.com^
@@ -22077,7 +19460,6 @@ cdn-settings.appsflyersdk.com^
 ||log-upload-eur.mihoyo.com^
 ||log-upload.mihoyo.com^
 ||log-upload-os.mihoyo.com^
-||s3-analytics-events.easybrain.com^
 ||mgs123.com^
 ||metrics.sp0n.io^
 ||liveme-sensors-collect2-*.amazonaws.com^
@@ -22091,7 +19473,6 @@ cdn-settings.appsflyersdk.com^
 ||dns-clientinfo.cbsivideo.com^
 ||report.*.qq.com^
 ||events.tvtime.com^
-||geico.com.ssl.sc.omtrdc.net^
 ||dit.whatsapp.net^
 ||analytics.redbubble.com^
 ||stats-sg.ganymede.eu^
@@ -22114,10 +19495,6 @@ cdn-settings.appsflyersdk.com^
 ||log-api.aillis.net^
 ||log.snow.me^
 ||events.textme-app.com^
-||stocks-analytics-events.apple.com^
-||stocks-analytics-events.news.apple-dns.net^
-||books-analytics-events.apple.com^
-||books-analytics-events.news.apple-dns.net^
 ||us04logfiles.zoom.us^
 ||us04logfiles-va.zoom.us^
 ||costco-adbutler.com^
@@ -22146,7 +19523,6 @@ cdn-settings.appsflyersdk.com^
 ||telemetry.voxeet.com^
 ||usertrack.appcpi.net^
 ||api*.amplitude.com^
-||conversions.appsflyer.com^
 ||collect.serious.li^
 ||analytics.jodelapis.com^
 ||analytics.mobilegamestats.com^
@@ -22171,8 +19547,6 @@ cdn-settings.appsflyersdk.com^
 ||tracker.departapp.com^
 ||us-tracking.nextdoor.com^
 ||us-events.api.iheart.com^
-||notes-analytics-events.apple.com^
-||weather-analytics-events.apple.com^
 ||v-collector.dp.aws.charter.com^
 ||metrics.claspws.tv^
 ||logs.gaaana.com^
@@ -22202,9 +19576,7 @@ cdn-settings.appsflyersdk.com^
 ||logsink.zedge.net^
 ||consent-manager-events.ogury.io^
 ||api.share.mob.com^
-||m.data.mob.com^
 ||bi.manhuaren.com^
-||c.data.mob.com^
 ||analytics.datasavannah.com^
 ||sq.requestads.com^
 ||insight.ucweb.com^
@@ -22243,7 +19615,6 @@ cdn-settings.appsflyersdk.com^
 ||adtrack.appcpi.net^
 ||remain.appcpi.net^
 ||appmetr.com^
-||track.tenjin.io^
 ||stats.abbi.io^
 ||api.goodbarber.net/statsapi/
 ||tracking.aatkit.com^
@@ -22293,10 +19664,8 @@ cdn-settings.appsflyersdk.com^
 ||fdplttrk.com^
 ||tracking.trnox.com^
 ||rts.mobula.sdk.duapps.com^
-||aftonbladetnya.sc.omtrdc.net^
 ||omni-ads.omni.news^
 ||npario-inc.net^
-||engine.mobileapptracking.com^
 ||wzrkt.com^
 ||analytics-events.inshorts.com^
 ||e-ssl.apsalar.com^
@@ -22305,7 +19674,6 @@ cdn-settings.appsflyersdk.com^
 ||sync.adotmob.com^
 ||logger.cloudmobi.net^
 ||tracker.adotmob.com^
-||dmx.sync.yume.com/tracker/
 ||measuread.com^
 ||global.cmcs.service.amazonsilk.com/metrics
 ||analytics-tracker.thescore.com^
@@ -22336,7 +19704,6 @@ cdn-settings.appsflyersdk.com^
 ||api.segment.io^
 ||applog.uc.cn^
 ||dispatcher.upmc.uc.cn^
-||gj.applog.uc.cn^
 ||gjapplog.uc.cn^
 ||a.bitmango.com^
 ||bitmango.com/log
@@ -22366,14 +19733,11 @@ cdn-settings.appsflyersdk.com^
 ||advmob.cn^
 ||alog.umeng.com^
 ||alog.umengcloud.com^
-||analytics.ad.daum.net^
 ||analytics.liftoff.io^
-||analytics.query.yahoo.com^
 ||analyzer.omniata.com^
 ||andmlb.kshwtj.com^
 ||api-analytics-bootstrap.metaps.com^
 ||api-analytics.metaps.com^
-||api.amplitude.com^
 ||api.analytics.omgpop.com^
 ||api.appsee.com^
 ||api.apptentive.com^
@@ -22391,7 +19755,6 @@ cdn-settings.appsflyersdk.com^
 ||bidder.mdspinc.com^
 ||bmbs.baidu.com/reportinfo.php
 ||brahe.apptimize.com^
-||carfax.sc.omtrdc.net^
 ||cb.ksmobile.com^
 ||cedexis-radar.net^
 ||cedexis.com^
@@ -22404,7 +19767,6 @@ cdn-settings.appsflyersdk.com^
 ||counter.kingsoft.com^
 ||crasheye.cn^
 ||crittercism.com/api/
-||dsg.sc.omtrdc.net^
 ||ep.xone.com^
 ||etl.xlmc.sandai.net^
 ||events.lbesecapi.com^
@@ -22433,7 +19795,6 @@ cdn-settings.appsflyersdk.com^
 ||mlb.did.ijinshan.com^
 ||mobile-collector.newrelic.com^
 ||mobile-global.baidu.com/mbrowser/stat/
-||mobileanalytics.*.amazonaws.com^
 ||mobilelog.upqzfile.com^
 ||ms.cmcm.com^
 ||mtlog.droid4x.cn^
@@ -22452,14 +19813,11 @@ cdn-settings.appsflyersdk.com^
 ||quantcount.com^
 ||rc.dxsvr.com^
 ||regist.fotoable.net/regist/
-||report.appmetrica.yandex.net^
 ||rlog-api.under9.co^
 ||rlog.9gag.com^
 ||sc-analytics.appspot.com^
 ||sdk-api.yozio.com/?os
 ||sdk.appbrain.com/api/
-||ssl-google-analytics.l.google.com^
-||sstats.economist.com/b/ss/econdarwinproduction/
 ||stat.duokanbox.com^
 ||statistics.videofarm.daum.net^
 ||stats.popcap.com^
@@ -22467,7 +19825,6 @@ cdn-settings.appsflyersdk.com^
 ||taurus.iad.appboy.com^
 ||tknet.rayjump.com^
 ||track.pingstart.com^
-||tracker-api.my.com^
 ||tracking.lenzmx.com^
 ||trk.pinterest.com^
 ||tu.dxcnd.cn^
@@ -22477,9 +19834,7 @@ cdn-settings.appsflyersdk.com^
 ||upalytics.com^
 ||ups.ksmobile.net^
 ||ws.ksmobile.net^
-||www-google-analytics.l.google.com^
 ||yadro.ru^
-||yikyakapi.net/api/logEvent?
 ||ymtracking.com^
 ! UC Browser
 ||localytics.com^
@@ -22520,7 +19875,6 @@ cdn-settings.appsflyersdk.com^
 @@||redirect.appmetrica.yandex.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/23294
 @@||79423.analytics.edgekey.net^|
-@@||79423.analytics.edgekey.net/html5/akamaihtml5-min.js$domain=nhk.or.jp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/19399
 @@||google-analytics.com/analytics.js$domain=brownbagcoffee.co.kr
 @@||google-analytics.com/gtm/js^$domain=brownbagcoffee.co.kr
@@ -22544,7 +19898,6 @@ cdn-settings.appsflyersdk.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/125637
 ! TODO: remove after fixing https://github.com/AdguardTeam/Scriptlets/issues/233
 ! checked 15.09.2022
-@@||googletagmanager.com/gtm.js$domain=expressvpn.com
 @@||google-analytics.com/analytics.js$script,redirect-rule,domain=expressvpn.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/125637
 ! TODO: remove after fixing https://github.com/AdguardTeam/Scriptlets/issues/233
@@ -22570,12 +19923,9 @@ cdn-settings.appsflyersdk.com^
 ! https://github.com/AdguardTeam/AdguardFilters/pull/141838
 @@||stat.tiara.kakao.com/track?d=*%22%3A%22go_*%22%$domain=map.kakao.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/142491
-@@||scdn.cxense.com/cx.cce.js$domain=cdn.cxpublic.com
 @@||cdn.cxense.com/cx.js$domain=cdn.cxpublic.com
 @@||api.cxense.com/public/widget/$domain=cdn.cxpublic.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/142569
-@@||cm-widget.nakanohito.jp/cm/$script,stylesheet
-@@||cm-beacon.nakanohito.jp/cm/comment_$xmlhttprequest
 ! https://github.com/AdguardTeam/AdguardFilters/issues/142567
 @@||csm.cxpublic.com/nikkansports.js$domain=nikkansports.com,script
 ! https://github.com/AdguardTeam/AdguardFilters/issues/142640

--- a/privacy_extended.txt
+++ b/privacy_extended.txt
@@ -1,6 +1,3 @@
-Privacy Extended after removing internal duplicates and redundancies with EasyPrivacy.
-11 March 2023
-
 ! Title: Privacy Extended
 ! Description: Privacy filters forked from Adguard Tracking Protection, optimized for uBlock Origin
 ! Expires: 12 hours


### PR DESCRIPTION
Redundancies removed within the list itself and when compared with EasyPrivacy, making Privacy Extended **11% leaner** (#2).

You'll need to go through and remove the leftover comments that are no longer applicable (e.g., `disguised trackers` section).